### PR TITLE
remove double triggered CI jobs in PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Python package
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
 


### PR DESCRIPTION
With `on: [push, pull_request]`, CI jobs get triggered twice in PRs, because you are both doing a pull request *and* pushing to the PR branch. This is a bit wasteful and also clutters the Actions pages. This PR changes the `on` triggers to run on either pull requests to master or on direct pushes to master. This means it doesn't trigger builds on other branches anymore, but if you want CI on a branch you can still just open a (draft) PR.