### PR TITLE
Replace dead URL to rest/sphinx cheatsheet

### DIFF
--- a/project_setup.md
+++ b/project_setup.md
@@ -53,7 +53,7 @@ help you decide which tool to use for packaging.
 
 - Documentation should be put in the [`docs/`](docs/) directory. The contents have been generated using `sphinx-quickstart` (Sphinx version 1.6.5).
 - We recommend writing the documentation using Restructured Text (reST) and Google style docstrings.
-  - [Restructured Text (reST) and Sphinx CheatSheet](http://openalea.gforge.inria.fr/doc/openalea/doc/_build/html/source/sphinx/rest_syntax.html)
+  - [Restructured Text (reST) primer](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)
   - [Google style docstring examples](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
 - The documentation is set up with the ReadTheDocs Sphinx theme.
   - Check out its [configuration options](https://sphinx-rtd-theme.readthedocs.io/en/latest/).


### PR DESCRIPTION
The markdown link checker has been failing for a while due to a dead link to a sphinx/rest cheatsheet.
I replaced it by a link to the ReST primer on the sphinx docs page, which should hopefully not disappear.