### PR TITLE
add a proof of concept jupyter widgets version of the gui/dashboard mockup

### DIFF
--- a/dianna/dashboard/Model Explanation Matrix v2.ipynb
+++ b/dianna/dashboard/Model Explanation Matrix v2.ipynb
@@ -1,0 +1,298 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5a2db590",
+   "metadata": {},
+   "source": [
+    "# Model explanation matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b64411a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get model and explainer up and running"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "90e294f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import Button, GridBox, Layout, ButtonStyle, HTML, Image\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "783e10ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use this margin to eliminate space between the image and the box\n",
+    "image_margin = '0 0 0 0'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c9aef8ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im_hot_dog = requests.get(hot_dog_url, allow_redirects=True).content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6e5bbc18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im_hound_dog = requests.get(hound_dog_url, allow_redirects=True).content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0098eaaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ib = Image(value=im_hot_dog, grid_area='im_hot_dog')\n",
+    "ib.layout.margin = image_margin\n",
+    "\n",
+    "ib2 = Image(value=im_hot_dog, grid_area='im_other_animal')\n",
+    "ib2.layout.margin = image_margin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "82515f4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f26a331b8bc244a3a35053b253136bd1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GridBox(children=(Button(description='Classes', layout=Layout(grid_area='classes', width='auto'), style=Button…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "classes = Button(description='Classes',\n",
+    "                 layout=Layout(width='auto', grid_area='classes'),\n",
+    "                 style=ButtonStyle(button_color='gray'))\n",
+    "colorbar = Button(description='Colorbar',\n",
+    "                 layout=Layout(width='auto', grid_area='colorbar'),\n",
+    "                 style=ButtonStyle(button_color='yellow'))\n",
+    "header  = Button(description='Header',\n",
+    "                 layout=Layout(width='auto', grid_area='header'),\n",
+    "                 style=ButtonStyle(button_color='lightblue'))\n",
+    "\n",
+    "\n",
+    "def flip_ib2_callback(b):\n",
+    "    if ib2.value == im_hot_dog:\n",
+    "        ib2.value = im_hound_dog\n",
+    "    else:\n",
+    "        ib2.value = im_hot_dog\n",
+    "\n",
+    "\n",
+    "FLIPPEM  = Button(description='PRESS ME',\n",
+    "                 layout=Layout(width='auto', grid_area='FLIPPEM'),\n",
+    "                 style=ButtonStyle(button_color='red'))\n",
+    "FLIPPEM.on_click(flip_ib2_callback)\n",
+    "\n",
+    "models = [\"model1\", \"model2\", \"model3\"]\n",
+    "explainers = [\"lime\", \"rise\", \"shap\"]\n",
+    "\n",
+    "data_items = [ib, ib, ib2, ib, ib, ib, ib, ib, ib]\n",
+    "\n",
+    "# for model in models:\n",
+    "#     for explainer in explainers:\n",
+    "\n",
+    "main    = GridBox(children=data_items,\n",
+    "            layout=Layout(\n",
+    "            width='300%',\n",
+    "            grid_template_rows='33% 33% 33%',\n",
+    "            grid_template_columns='33% 33% 33%',\n",
+    "            grid_template_areas='''\n",
+    "              \"im_hotdog im_hotdog im_hotdog\"\n",
+    "              \"im_hotdog im_hotdog im_hotdog\"\n",
+    "              \"im_hotdog im_hotdog im_hotdog\"\n",
+    "              '''\n",
+    "            )\n",
+    "       )\n",
+    "\n",
+    "sidebar = Button(description='Sidebar',\n",
+    "                 layout=Layout(width='auto', grid_area='sidebar'),\n",
+    "                 style=ButtonStyle(button_color='salmon'))\n",
+    "footer  = Button(description='Footer',\n",
+    "                 layout=Layout(width='auto', grid_area='footer'),\n",
+    "                 style=ButtonStyle(button_color='olive'))\n",
+    "\n",
+    "GridBox(children=[classes, colorbar, FLIPPEM, header, main, footer,],\n",
+    "        layout=Layout(\n",
+    "            width='100%',\n",
+    "            grid_template_rows='25% 25% 25% 25%',\n",
+    "            grid_template_columns='20% 20% 20% 20% 20%',\n",
+    "            grid_template_areas='''\n",
+    "            \"header header header header header\"\n",
+    "            \"classes main main main colorbar\"\n",
+    "            \"FLIPPEM main main main colorbar\"\n",
+    "            \"footer footer footer footer footer\"\n",
+    "            ''')\n",
+    "       )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "852a840a",
+   "metadata": {},
+   "source": [
+    "# Part 2: text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cddd2cc0",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3612937815644b5fbc3e3e891a84c514",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GridBox(children=(Button(description='Classes', layout=Layout(grid_area='classes', width='auto'), style=Button…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "classes = Button(description='Classes',\n",
+    "                 layout=Layout(width='auto', grid_area='classes'),\n",
+    "                 style=ButtonStyle(button_color='gray'))\n",
+    "colorbar = Button(description='Colorbar',\n",
+    "                 layout=Layout(width='auto', grid_area='colorbar'),\n",
+    "                 style=ButtonStyle(button_color='yellow'))\n",
+    "header  = Button(description='Header',\n",
+    "                 layout=Layout(width='auto', grid_area='header'),\n",
+    "                 style=ButtonStyle(button_color='lightblue'))\n",
+    "\n",
+    "models = [\"model1\", \"model2\", \"model3\"]\n",
+    "explainers = [\"lime\", \"rise\", \"shap\"]\n",
+    "\n",
+    "data_items = []\n",
+    "\n",
+    "for model in models:\n",
+    "    for explainer in explainers:\n",
+    "        text_explainer_widget = HTML(value=f'<p>{explainer} on {model}: <b>bla</b>bla</p>',\n",
+    "                                     grid_area=explainer+'_'+model)\n",
+    "        data_items.append(text_explainer_widget)\n",
+    "\n",
+    "main    = GridBox(children=data_items,\n",
+    "            layout=Layout(\n",
+    "            width='300%',\n",
+    "            grid_template_rows='33% 33% 33%',\n",
+    "            grid_template_columns='33% 33% 33%',\n",
+    "            grid_template_areas='''\n",
+    "            \"lime_model1 rise_model1 shap_model1\"\n",
+    "            \"lime_model2 rise_model2 shap_model2\"\n",
+    "            \"lime_model3 rise_model3 shap_model3\"\n",
+    "            '''\n",
+    "            )\n",
+    "       )\n",
+    "\n",
+    "sidebar = Button(description='Sidebar',\n",
+    "                 layout=Layout(width='auto', grid_area='sidebar'),\n",
+    "                 style=ButtonStyle(button_color='salmon'))\n",
+    "footer  = Button(description='Footer',\n",
+    "                 layout=Layout(width='auto', grid_area='footer'),\n",
+    "                 style=ButtonStyle(button_color='olive'))\n",
+    "\n",
+    "GridBox(children=[classes, colorbar, header, main, footer, ],\n",
+    "        layout=Layout(\n",
+    "            width='100%',\n",
+    "            grid_template_rows='25% 25% 25% 25%',\n",
+    "            grid_template_columns='20% 20% 20% 20% 20%',\n",
+    "            grid_template_areas='''\n",
+    "            \"header header header header header\"\n",
+    "            \"classes main main main colorbar\"\n",
+    "            \".       main main main colorbar\"\n",
+    "            \"footer footer footer footer footer\"\n",
+    "            ''')\n",
+    "       )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c812d8f9",
+   "metadata": {},
+   "source": [
+    "# Questions/Todo\n",
+    "\n",
+    "1. How do we do colorbars? They may be different per explainer, and even per explainer-model combination. Do we even output colorbars in our current `dianna.visualization` module?\n",
+    "2. We need column/row labels.\n",
+    "3. We need a way to load models. File loader widget? Other?\n",
+    "4. We need a way to add data items\n",
+    "    1. For text: could just be a sentence, or what ever kind of text the model can take as input. So just a textbox.\n",
+    "    2. For images: need file loader widget again.\n",
+    "5. Colorbar should be colorbar/legend.\n",
+    "6. Class list needs to be added as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43cb5519",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/dianna/dashboard/Model Explanation Matrix.ipynb
+++ b/dianna/dashboard/Model Explanation Matrix.ipynb
@@ -1,0 +1,302 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5a2db590",
+   "metadata": {},
+   "source": [
+    "# Try me out in Voilà for dashboard mode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "90e294f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import Button, GridBox, Layout, ButtonStyle, HTML, Image\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "783e10ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use this margin to eliminate space between the image and the box\n",
+    "image_margin = '0 0 0 0'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ed81fad9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# some cool images from:\n",
+    "# Arrieta et al. 2019\n",
+    "# Explainable Artificial Intelligence (XAI): Concepts, Taxonomies, Opportunities and Challenges toward Responsible AI\n",
+    "hot_dog_url = 'https://www.researchgate.net/profile/Natalia-Diaz-Rodriguez/publication/336734529/figure/fig4/AS:817007322726411@1571801133456/Examples-of-rendering-for-different-XAI-visualization-techniques-on-images_W640.jpg'\n",
+    "hound_dog_url = 'https://www.researchgate.net/profile/Natalia-Diaz-Rodriguez/publication/336734529/figure/fig6/AS:817007322734604@1571801133645/Examples-of-explanation-when-using-LIME-on-images-71_W640.jpg'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c9aef8ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im_hot_dog = requests.get(hot_dog_url, allow_redirects=True).content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6e5bbc18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im_hound_dog = requests.get(hound_dog_url, allow_redirects=True).content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0098eaaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ib = Image(value=im_hot_dog, grid_area='im_hot_dog')\n",
+    "ib.layout.margin = image_margin\n",
+    "\n",
+    "ib2 = Image(value=im_hot_dog, grid_area='im_other_animal')\n",
+    "ib2.layout.margin = image_margin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "82515f4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f26a331b8bc244a3a35053b253136bd1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GridBox(children=(Button(description='Classes', layout=Layout(grid_area='classes', width='auto'), style=Button…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "classes = Button(description='Classes',\n",
+    "                 layout=Layout(width='auto', grid_area='classes'),\n",
+    "                 style=ButtonStyle(button_color='gray'))\n",
+    "colorbar = Button(description='Colorbar',\n",
+    "                 layout=Layout(width='auto', grid_area='colorbar'),\n",
+    "                 style=ButtonStyle(button_color='yellow'))\n",
+    "header  = Button(description='Header',\n",
+    "                 layout=Layout(width='auto', grid_area='header'),\n",
+    "                 style=ButtonStyle(button_color='lightblue'))\n",
+    "\n",
+    "\n",
+    "def flip_ib2_callback(b):\n",
+    "    if ib2.value == im_hot_dog:\n",
+    "        ib2.value = im_hound_dog\n",
+    "    else:\n",
+    "        ib2.value = im_hot_dog\n",
+    "\n",
+    "\n",
+    "FLIPPEM  = Button(description='PRESS ME',\n",
+    "                 layout=Layout(width='auto', grid_area='FLIPPEM'),\n",
+    "                 style=ButtonStyle(button_color='red'))\n",
+    "FLIPPEM.on_click(flip_ib2_callback)\n",
+    "\n",
+    "models = [\"model1\", \"model2\", \"model3\"]\n",
+    "explainers = [\"lime\", \"rise\", \"shap\"]\n",
+    "\n",
+    "data_items = [ib, ib, ib2, ib, ib, ib, ib, ib, ib]\n",
+    "\n",
+    "# for model in models:\n",
+    "#     for explainer in explainers:\n",
+    "\n",
+    "main    = GridBox(children=data_items,\n",
+    "            layout=Layout(\n",
+    "            width='300%',\n",
+    "            grid_template_rows='33% 33% 33%',\n",
+    "            grid_template_columns='33% 33% 33%',\n",
+    "            grid_template_areas='''\n",
+    "              \"im_hotdog im_hotdog im_hotdog\"\n",
+    "              \"im_hotdog im_hotdog im_hotdog\"\n",
+    "              \"im_hotdog im_hotdog im_hotdog\"\n",
+    "              '''\n",
+    "            )\n",
+    "       )\n",
+    "\n",
+    "sidebar = Button(description='Sidebar',\n",
+    "                 layout=Layout(width='auto', grid_area='sidebar'),\n",
+    "                 style=ButtonStyle(button_color='salmon'))\n",
+    "footer  = Button(description='Footer',\n",
+    "                 layout=Layout(width='auto', grid_area='footer'),\n",
+    "                 style=ButtonStyle(button_color='olive'))\n",
+    "\n",
+    "GridBox(children=[classes, colorbar, FLIPPEM, header, main, footer,],\n",
+    "        layout=Layout(\n",
+    "            width='100%',\n",
+    "            grid_template_rows='25% 25% 25% 25%',\n",
+    "            grid_template_columns='20% 20% 20% 20% 20%',\n",
+    "            grid_template_areas='''\n",
+    "            \"header header header header header\"\n",
+    "            \"classes main main main colorbar\"\n",
+    "            \"FLIPPEM main main main colorbar\"\n",
+    "            \"footer footer footer footer footer\"\n",
+    "            ''')\n",
+    "       )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "852a840a",
+   "metadata": {},
+   "source": [
+    "# Part 2: text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cddd2cc0",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3612937815644b5fbc3e3e891a84c514",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GridBox(children=(Button(description='Classes', layout=Layout(grid_area='classes', width='auto'), style=Button…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "classes = Button(description='Classes',\n",
+    "                 layout=Layout(width='auto', grid_area='classes'),\n",
+    "                 style=ButtonStyle(button_color='gray'))\n",
+    "colorbar = Button(description='Colorbar',\n",
+    "                 layout=Layout(width='auto', grid_area='colorbar'),\n",
+    "                 style=ButtonStyle(button_color='yellow'))\n",
+    "header  = Button(description='Header',\n",
+    "                 layout=Layout(width='auto', grid_area='header'),\n",
+    "                 style=ButtonStyle(button_color='lightblue'))\n",
+    "\n",
+    "models = [\"model1\", \"model2\", \"model3\"]\n",
+    "explainers = [\"lime\", \"rise\", \"shap\"]\n",
+    "\n",
+    "data_items = []\n",
+    "\n",
+    "for model in models:\n",
+    "    for explainer in explainers:\n",
+    "        text_explainer_widget = HTML(value=f'<p>{explainer} on {model}: <b>bla</b>bla</p>',\n",
+    "                                     grid_area=explainer+'_'+model)\n",
+    "        data_items.append(text_explainer_widget)\n",
+    "\n",
+    "main    = GridBox(children=data_items,\n",
+    "            layout=Layout(\n",
+    "            width='300%',\n",
+    "            grid_template_rows='33% 33% 33%',\n",
+    "            grid_template_columns='33% 33% 33%',\n",
+    "            grid_template_areas='''\n",
+    "            \"lime_model1 rise_model1 shap_model1\"\n",
+    "            \"lime_model2 rise_model2 shap_model2\"\n",
+    "            \"lime_model3 rise_model3 shap_model3\"\n",
+    "            '''\n",
+    "            )\n",
+    "       )\n",
+    "\n",
+    "sidebar = Button(description='Sidebar',\n",
+    "                 layout=Layout(width='auto', grid_area='sidebar'),\n",
+    "                 style=ButtonStyle(button_color='salmon'))\n",
+    "footer  = Button(description='Footer',\n",
+    "                 layout=Layout(width='auto', grid_area='footer'),\n",
+    "                 style=ButtonStyle(button_color='olive'))\n",
+    "\n",
+    "GridBox(children=[classes, colorbar, header, main, footer, ],\n",
+    "        layout=Layout(\n",
+    "            width='100%',\n",
+    "            grid_template_rows='25% 25% 25% 25%',\n",
+    "            grid_template_columns='20% 20% 20% 20% 20%',\n",
+    "            grid_template_areas='''\n",
+    "            \"header header header header header\"\n",
+    "            \"classes main main main colorbar\"\n",
+    "            \".       main main main colorbar\"\n",
+    "            \"footer footer footer footer footer\"\n",
+    "            ''')\n",
+    "       )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c812d8f9",
+   "metadata": {},
+   "source": [
+    "# Questions/Todo\n",
+    "\n",
+    "1. How do we do colorbars? They may be different per explainer, and even per explainer-model combination. Do we even output colorbars in our current `dianna.visualization` module?\n",
+    "2. We need column/row labels.\n",
+    "3. We need a way to load models. File loader widget? Other?\n",
+    "4. We need a way to add data items\n",
+    "    1. For text: could just be a sentence, or what ever kind of text the model can take as input. So just a textbox.\n",
+    "    2. For images: need file loader widget again.\n",
+    "5. Colorbar should be colorbar/legend.\n",
+    "6. Class list needs to be added as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43cb5519",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
@elboyran and I have made a first proof of concept version of the mockup in #41. In this draft PR, we can keep track of progress and discuss ways to improve. We already identified the following questions and/or todo items:

### Questions/Todo

1. How do we do colorbars? They may be different per explainer, and even per explainer-model combination. Do we even output colorbars in our current `dianna.visualization` module?
2. We need column/row labels.
3. We need a way to load models. File loader widget? Other?
4. We need a way to add data items
    1. For text: could just be a sentence, or what ever kind of text the model can take as input. So just a textbox.
    2. For images: need file loader widget again.
5. Colorbar should be colorbar/legend.
6. Class list needs to be added as well.

### Screenshots:
Image dashboard:
![Schermafbeelding 2021-12-14 om 12 51 17](https://user-images.githubusercontent.com/6146598/145993153-514249eb-50b5-4669-8fd5-33cc66287477.png)

Text dashboard:
![Schermafbeelding 2021-12-14 om 12 51 33](https://user-images.githubusercontent.com/6146598/145993182-14054bdb-694b-457a-9213-ef7e4d1e739f.png)

