### PR TITLE
Allow all method keyword arguments

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check style against standards using prospector
         run: prospector --zero-exit --output-format grouped --output-format pylint:pylint-report.txt
       - name: Run unit tests with coverage
-        run: pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml tests/
+        run: pytest --cov --cov-report term --cov-report xml --cov-report html --junitxml=xunit-result.xml tests/
       - name: Correct coverage paths
         run: sed -i "s+$PWD/++g" coverage.xml
       - name: SonarCloud Scan

--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,13 @@ dist
 .cache
 __pycache__
 
+# testing
 htmlcov
 .coverage
 coverage.xml
 .pytest_cache
+.tox
+word_vectors.txt.pt
 
 docs/_build
 

--- a/dianna/methods/lime.py
+++ b/dianna/methods/lime.py
@@ -74,7 +74,9 @@ class LIME:
                                                  the path to a ONNX model on disk.
             input_data (np.ndarray): Data to be explained
             labels ([int], optional): Iterable of indices of class to be explained
-        Other keyword arguments: see the LIME documentation for LimeTextExplainer.explain_instance.
+
+        Other keyword arguments: see the LIME documentation for LimeTextExplainer.explain_instance:
+        https://lime-ml.readthedocs.io/en/latest/lime.html#lime.lime_text.LimeTextExplainer.explain_instance.
 
         Returns:
             list of (word, index of word in raw text, importance for target class) tuples
@@ -119,7 +121,10 @@ class LIME:
             input_data (np.ndarray): Data to be explained
             label (int): Index of class to be explained
         Other keyword arguments: see the LIME documentation for LimeImageExplainer.explain_instance and
-        ImageExplanation.get_image_and_mask.
+        ImageExplanation.get_image_and_mask:
+
+        - https://lime-ml.readthedocs.io/en/latest/lime.html#lime.lime_image.LimeImageExplainer.explain_instance
+        - https://lime-ml.readthedocs.io/en/latest/lime.html#lime.lime_image.ImageExplanation.get_image_and_mask
 
         Returns:
             list of (word, index of word in raw text, importance for target class) tuples

--- a/dianna/utils/__init__.py
+++ b/dianna/utils/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa: F401
 from .misc import get_function
+from .misc import get_kwargs_applicable_to_function

--- a/dianna/utils/misc.py
+++ b/dianna/utils/misc.py
@@ -20,3 +20,14 @@ def get_function(model_or_function, preprocess_function=None):
     else:
         raise TypeError("model_or_function argument must be string (path to model) or function")
     return runner
+
+
+def get_kwargs_applicable_to_function(function, kwargs):
+    """
+    Returns a dict that is the subset of `kwargs` for which the keys are
+    keyword arguments of `function`. Note that if `function` has a `**kwargs`
+    argument, this function should not be necessary (provided the function
+    handles `**kwargs` robustly).
+    """
+    return {key: value for key, value in kwargs.items()
+            if key in function.__code__.co_varnames}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,23 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+source = ["dianna"]
+command_line = "-m pytest"
+
+[tool.tox]
+legacy_tox_ini = """
+[tox]
+envlist = py37,py38,py39
+skip_missing_interpreters = true
+
+[testenv]
+commands = pytest
+extras = dev
+"""
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,16 +60,13 @@ dev =
     sphinx_rtd_theme
     sphinx-autoapi
     torchtext
+    coverage [toml]
 publishing =
     twine
     wheel
 
 [options.packages.find]
 include = dianna, dianna.*
-
-[coverage:run]
-branch = True
-source = dianna
 
 [isort]
 lines_after_imports = 2
@@ -79,8 +76,3 @@ known_first_party = dianna
 src_paths = dianna,tests
 line_length = 120
 
-[tool:pytest]
-testpaths = tests
-# Note that visual debugger in some editors like pycharm gets confused by coverage calculation.
-# As a workaround, configure the test configuration in pycharm et al with a --no-cov argument
-addopts = --cov --cov-report xml --cov-report term --cov-report html


### PR DESCRIPTION
This PR will allow users to pass along all possible keyword arguments to the explainer methods. It does this by adding `**kwargs` to the `explain_image/text` functions and passing them along appropriately (i.e. forwarding the proper keyword arguments to the proper call sites; some explanation methods need multiple calls and these calls may not support the same set of keyword arguments, so we need to filter the `**kwargs` dict for which a helper function was created in `utils`).

I propose to also remove a few existing keyword arguments that had the same defaults as those in the explainer libraries. These can now still be changed by the user by providing it through `**kwargs`, but we don't have to maintain the default values anymore.

Finally, I update documentation on our side a bit. We listed all parameters, but didn't explain them. I now simply refer to the method's documentation for those.

~This is still WIP, I only did LIME for now.~ LIME is also the only method to which this is relevant, right?

Oh, and ~another~ two other things: The first commit in this PR "fixes" testing and coverage configuration. Maybe this breaks CI in some way, in which case I'll try to fix it. But the reason is that the previous configuration broke test discovery in IDEs (VSCode and PyCharm at least). This should fix that. Please try it out! The second thing is a small commit that adds `tox` support. Now that configuration is all worked out, `tox` is a super convenient way to run tests on your laptop in a clean environment. This helps catch dependency configuration errors a bit faster, because you may have installed deps in your local environment manually but forgot to add them to the deps list. Just personal preference, using pytest without tox can work fine as well :)

Fixes #68