### PR TITLE
Remove explicit dtype conversion in SimpleModelRunner

### DIFF
--- a/dianna/utils/onnx_runner.py
+++ b/dianna/utils/onnx_runner.py
@@ -1,4 +1,3 @@
-import numpy as np
 import onnxruntime as ort
 
 
@@ -29,6 +28,6 @@ class SimpleModelRunner:
         if self.preprocess_function is not None:
             input_data = self.preprocess_function(input_data)
 
-        onnx_input = {input_name: input_data.astype(np.float32)}
+        onnx_input = {input_name: input_data}
         pred_onnx = sess.run([output_name], onnx_input)[0]
         return pred_onnx

--- a/tests/test_lime.py
+++ b/tests/test_lime.py
@@ -29,7 +29,7 @@ class LimeOnImages(TestCase):
 
         def preprocess(data):
             data = data[..., 0][..., None]
-            return np.moveaxis(data, -1, 1)
+            return np.moveaxis(data, -1, 1).astype(np.float32)
 
         heatmap = dianna.explain_image(model_filename, input_data, method="LIME", preprocess_function=preprocess, random_state=42)
 

--- a/tests/test_onnx_runner.py
+++ b/tests/test_onnx_runner.py
@@ -12,6 +12,6 @@ def test_onnx_runner():
     batch_size = 3
 
     runner = SimpleModelRunner(filename)
-    pred_onnx = runner(generate_data(batch_size))
+    pred_onnx = runner(generate_data(batch_size).astype(np.float32))
 
     assert pred_onnx.shape == (batch_size, n_classes)

--- a/tests/test_rise.py
+++ b/tests/test_rise.py
@@ -18,7 +18,7 @@ class RiseOnImages(TestCase):
 
     def test_rise_filename(self):
         model_filename = 'tests/test_data/mnist_model.onnx'
-        input_data = generate_data(batch_size=1)
+        input_data = generate_data(batch_size=1).astype(np.float32)
 
         heatmaps = dianna.explain_image(model_filename, input_data, method="RISE", n_masks=200)
 


### PR DESCRIPTION
Now that we keep track of the dtype of the data given by the user, we no longer 
need to do any conversion explicitly. 

This PR removes the explicit conversion to float32 in SimpleModelRunner, and adds explicit conversion
of the input data used in tests.