### PR TITLE
Set prospector to strict linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Check style against standards using prospector
         run: prospector
       - name: Check import order
-        run: isort --recursive --check-only dianna
+        run: isort --check-only dianna --diff

--- a/.prospector.yml
+++ b/.prospector.yml
@@ -4,10 +4,11 @@
 
 output-format: grouped
 
-strictness: medium
-doc-warnings: false
+strictness: veryhigh
+doc-warnings: true
 test-warnings: true
-member-warnings: false
+member-warnings: true
+max-line-length: 127
 
 ignore-paths:
   - docs

--- a/.prospector.yml
+++ b/.prospector.yml
@@ -28,3 +28,8 @@ pep257:
         D213,  # Multi-line docstring summary should start at the second line
         D404,  # First word of the docstring should not be This
     ]
+
+mypy:
+    run: true
+    options:
+        ignore-missing-imports: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ install_requires =
 dev =
     bump2version
     prospector[with_pyroma]
+    mypy
     isort
     pytest
     pytest-cov


### PR DESCRIPTION
Line length 127 is the average of 3*42 and 128, which are both nice numbers.

This makes #74 obsolete, because docstring linting is also included here now. ~Except that that branch changed the `isort` call, that should be added here as well.~

This may also fix #84, but we should make sure.

I also added mypy linting, in anticipation of #85. Mypy passes without messages right now.