### PR TITLE
add notebooks extras_require for running notebooks

### DIFF
--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -23,4 +23,4 @@ runs:
       shell: bash {0}
       run: |
         python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install .[dev,publishing]
+        python3 -m pip install .[dev,publishing,notebooks]

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,8 @@ dev =
 publishing =
     twine
     wheel
+notebooks =
+    torchvision
 
 [options.packages.find]
 include = dianna, dianna.*


### PR DESCRIPTION
Currently the notebooks action in main is failing. One of the issues is that it misses the torchvision requirement. This PR fixes that issue. Other issues still remain after this PR, for instance, the missing ferrari.jpg (of which the license is unclear).
Feel free to merge if you approve. It's a tiny PR anyway.