### PR TITLE
optimize CI pip dependency installation

### DIFF
--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -5,6 +5,10 @@ inputs:
     required: false
     description: "The Python version to use. Specify major and minor version, e.g. '3.9'."
     default: "3.9"
+  extras-require:
+    required: false
+    description: "The extras dependencies packages to be installed, for instance 'dev' or 'dev,publishing,notebooks'."
+    default: "dev"
 runs:
   using: "composite"
   steps:
@@ -22,5 +26,5 @@ runs:
     - name: Upgrade pip and install dependencies
       shell: bash {0}
       run: |
-        python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install .[dev,publishing,notebooks]
+        python3 -m pip install --upgrade pip setuptools wheel
+        python3 -m pip install .[${{ inputs.extras-require }}]

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -21,5 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/install-python-and-package
+        with:
+          extras-require: dev,notebooks
       - name: Run tutorial notebooks
         run: pytest --nbmake tutorials

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: ./.github/actions/install-python-and-package
+        with:
+          extras-require: publishing
 
       - name: Build wheel
         run: python setup.py bdist_wheel
@@ -29,6 +31,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: ./.github/actions/install-python-and-package
+        with:
+          extras-require: publishing
 
       - name: Build sdist
         run: python setup.py sdist


### PR DESCRIPTION
This commit/PR:

1. Adds the option in the install action to specify which extras-require options to use (dev, notebooks, publish).
2. Uses the above to minimize the dependencies that have to be installed for each workflow.
3. Installs wheel in the first step of the dependencies installation. This allows pip to download wheels in the second step (installing dianna and dependencies), which reduces install time.