### PR TITLE
In RISE for text, mask tokens with a user-definable string instead of removing  them

### DIFF
--- a/dianna/methods/rise.py
+++ b/dianna/methods/rise.py
@@ -19,7 +19,7 @@ class RISE:
     required_labels = ('batch', 'channels')
 
     def __init__(self, n_masks=1000, feature_res=8, p_keep=None,  # pylint: disable=too-many-arguments
-                 axis_labels=None, preprocess_function=None):
+                 axis_labels=None, preprocess_function=None, mask_string="UNKWORDZ"):
         """RISE initializer.
 
         Args:
@@ -30,6 +30,7 @@ class RISE:
                                                If a list, the name of each axis where the index
                                                in the list is the axis index
             preprocess_function (callable, optional): Function to preprocess input data with
+            mask_string (str, optional): String to replace masked tokens with (text only)
         """
         self.n_masks = n_masks
         self.feature_res = feature_res
@@ -38,6 +39,7 @@ class RISE:
         self.masks = None
         self.predictions = None
         self.axis_labels = axis_labels if axis_labels is not None else []
+        self.mask_string = mask_string
 
     def explain_text(self, model_or_function, input_text, labels=(0,), batch_size=100):
         """Runs the RISE explainer on text.
@@ -115,7 +117,7 @@ class RISE:
     def _create_masked_sentences(self, tokens, masks):
         tokens_masked = []
         for mask in masks:
-            tokens_masked.append(tokens[mask])
+            tokens_masked.append([token if keep else self.mask_string for token, keep in zip(tokens, mask)])
         sentences = [" ".join(t) for t in tokens_masked]
         return sentences
 

--- a/tests/test_rise.py
+++ b/tests/test_rise.py
@@ -57,7 +57,7 @@ class RiseOnText(TestCase):
         review = 'such a bad movie'
         expected_words = ['such', 'a', 'bad', 'movie']
         expected_word_indices = [0, 5, 7, 11]
-        expected_positive_scores = [0.3295266, 0.3521292, 0.023648001, 0.3347813]
+        expected_positive_scores = [0.3044678, 0.28736606, 0.03623142, 0.23650846]
 
         positive_explanation = dianna.explain_text(runner, review, labels=(1, 0), method='RISE', p_keep=.5)[0]
 
@@ -71,7 +71,7 @@ class RiseOnText(TestCase):
     def test_rise_determine_p_keep_for_text(self):
         """Tests exact expected p_keep given a text and model."""
         np.random.seed(0)
-        expected_p_exact_keep = .3
+        expected_p_exact_keep = .5
         model_path = 'tests/test_data/movie_review_model.onnx'
         word_vector_file = 'tests/test_data/word_vectors.txt'
         runner = ModelRunner(model_path, word_vector_file, max_filter_size=5)


### PR DESCRIPTION
The default mask string is "UNKWORDZ", which most likely isn't in any tokenizer's dictionary.
This is the same value as is used internally in LIME. The name of the parameter (`mask_string`) is also identical to LIME, the DIANNA API remains consistent with respect to this parameter.