### PR TITLE
An attempt at fixing slow import

### DIFF
--- a/dianna/__init__.py
+++ b/dianna/__init__.py
@@ -22,7 +22,6 @@ become a source of (scientific) insights.
 See https://github.com/dianna-ai/dianna
 """
 import logging
-from onnx_tf.backend import prepare  # To avoid Access Violation on Windows with SHAP
 from . import methods
 from . import utils
 
@@ -49,6 +48,8 @@ def explain_image(model_or_function, input_data, method, labels=(1,), **kwargs):
         One heatmap (2D array) per class.
 
     """
+    if method == "SHAP":
+        from onnx_tf.backend import prepare  # To avoid Access Violation on Windows with SHAP
     explainer = _get_explainer(method, kwargs)
     explain_image_kwargs = utils.get_kwargs_applicable_to_function(explainer.explain_image, kwargs)
     return explainer.explain_image(model_or_function, input_data, labels, **explain_image_kwargs)

--- a/dianna/methods/kernelshap.py
+++ b/dianna/methods/kernelshap.py
@@ -2,7 +2,6 @@ import warnings
 import numpy as np
 import shap
 import skimage.segmentation
-from onnx_tf.backend import prepare  # onnx to tf model converter&runner
 from dianna import utils
 
 
@@ -20,6 +19,8 @@ class KernelSHAP:
                                                in the list is the axis index
         """
         self.axis_labels = axis_labels if axis_labels is not None else []
+        from onnx_tf.backend import prepare
+        self.onnx_to_tf = prepare
 
     @staticmethod
     def _segment_image(
@@ -204,7 +205,7 @@ class KernelSHAP:
             features (np.ndarray): A matrix of samples (# samples x # features)
                                    on which to explain the model's output.
         """
-        return prepare(self.onnx_model).run(
+        return self.onnx_to_tf(self.onnx_model).run(
             self._mask_image(
                 features,
                 self.image_segments,

--- a/dianna/utils/misc.py
+++ b/dianna/utils/misc.py
@@ -1,7 +1,6 @@
 import inspect
 import onnx
 import xarray as xr
-from onnx_tf.backend import prepare
 from dianna.utils.onnx_runner import SimpleModelRunner
 
 
@@ -102,6 +101,7 @@ def onnx_model_node_loader(model_path):
     Returns:
         loaded onnx model and the label of output node.
     """
+    from onnx_tf.backend import prepare  # this import is done in the function because it is slow
     onnx_model = onnx.load(model_path)  # load onnx model
     tf_model_rep = prepare(onnx_model, gen_tensor_dict=True)
     label_input_node = tf_model_rep.inputs[0]


### PR DESCRIPTION
Currently, `import dianna` is slow (see #154).
This is an attempt at fixing (part of) that by only importing from`onnx_tf` when it wil actually be used.