### PR TITLE
Add cffconvert.yml to validate CITATION.cff

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -1,22 +1,19 @@
 name: cffconvert
 
 on:
-  workflow_dispatch:
   push:
-    branches:
-    - main
-  pull_request:
-    branches:
-    - main
+    paths:
+      - CITATION.cff
 
 jobs:
-
-  verify:
-    name: "cffconvert"
+  validate:
+    name: "validate"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        name: Check out a copy of the repository
+      - name: Check out a copy of the repository
+        uses: actions/checkout@v2
 
-      - uses: citation-file-format/cffconvert-github-action@main
-        name: Check whether the citation metadata from CITATION.cff is equivalent to that in .zenodo.json
+      - name: Check whether the citation metadata from CITATION.cff is valid
+        uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: "--validate"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 # YAML 1.2
 ---
-cff-version: "1.1.0"
+cff-version: 1.2.0
 title: "dianna"
 authors:
   -


### PR DESCRIPTION
Hello!

We noticed that your CITATION.cff had a small issue and fixed it - possibly by just updating `cffversion` to 1.2.0.
In addition to the fix, this PR also updates cffconvert-github-action to 2.0.0.
In the new version, the cffconvert-github-action does not compare against Zenodo anymore, because Zenodo is using CITATION.cff directly now (see [this twitter post](https://twitter.com/zenodo_org/status/1420357001490706442)).

BTW it's perfectly fine if you don't feel like accepting this Pull Request for whatever reason -- we just thought it might be helpful is all.

We found your repository using a partially automated workflow; if you have any questions about that, feel free to create an issue over at https://github.com/cffbots/filtering/issues/

On behalf of the cffbots team,
@abelsiqueira / @fdiblen / @jspaaks

PS. This should close #121 