### PR TITLE
Explicitly set setup-python version

### DIFF
--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.3.2
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'


### PR DESCRIPTION
Note: the version should be made less specific again once the general v2 tag is updated to v2.3.2 or later of setup-python