### PR TITLE
revisit joss skeleton

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -21,7 +21,6 @@ affiliations:
    index: 3
 date: dd Month yyyy
 bibliography: paper.bib
-
 ---
 
 # Summary
@@ -32,36 +31,13 @@ Summary goes here.
 
 Statement of need goes here.
 
-# Mathematics
+# State of the field
 
-Single dollars ($) are required for inline mathematics e.g. $f(x) = e^{\pi/x}$
+State of the field goes here.
 
-Double dollars make self-standing equations:
+# Key Features
 
-$$\Theta(x) = \left\{\begin{array}{l}
-0\textrm{ if } x < 0\cr
-1\textrm{ else}
-\end{array}\right.$$
-
-You can also use plain \LaTeX for equations
-\begin{equation}\label{eq:fourier}
-\hat f(\omega) = \int_{-\infty}^{\infty} f(x) e^{i\omega x} dx
-\end{equation}
-and refer to \autoref{eq:fourier} from text.
-
-# Citations
-
-Citations to entries in paper.bib should be in
-[rMarkdown](http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html)
-format.
-
-If you want to cite a software repository URL (e.g. something on GitHub without a preferred
-citation) then you can do it with the example BibTeX entry below for @fidgit.
-
-For a quick reference, the following citation commands can be used:
-- `@author:2001`  ->  "Author et al. (2001)"
-- `[@author:2001]` -> "(Author et al., 2001)"
-- `[@author1:2001; @author2:2001]` -> "(Author1 et al., 2001; Author2 et al., 2002)"
+Key features go here.
 
 # Figures
 
@@ -77,3 +53,5 @@ Figure sizes can be customized by adding an optional second parameter:
 Acks go here.
 
 # References
+
+@bibname


### PR DESCRIPTION
I removed Mathematics and Citations sections (I left References at the end as is done in the [recent paper example](https://joss.theoj.org/papers/10.21105/joss.03951)), and as it seems to be suggested in the [review criteria](https://joss.readthedocs.io/en/latest/review_criteria.html). I also inserted State of the field and Key Features sections. 

I left Figure section, also if I don't think is needed (see [recent paper example](https://joss.theoj.org/papers/10.21105/joss.03951))