### PR TITLE
Update CI

### DIFF
--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.7', '3.8', '3.9']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-python-and-package
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check whether the citation metadata from CITATION.cff is valid
         uses: citation-file-format/cffconvert-github-action@2.0.0

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-python-and-package
       - name: Install pandoc using apt
         run: sudo apt install pandoc        

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -6,7 +6,7 @@ jobs:
     name: Paper Draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@master
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-python-and-package
       - name: Check style against standards using prospector
         run: prospector

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-python-and-package
         with:
           extras-require: dev,notebooks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build universal wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/install-python-and-package
         with:
@@ -20,7 +20,7 @@ jobs:
       - name: Build wheel
         run: python setup.py bdist_wheel
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.whl
 
@@ -28,7 +28,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/install-python-and-package
         with:
@@ -37,7 +37,7 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -46,7 +46,7 @@ jobs:
     needs: [build_wheel, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,59 +7,37 @@ on:
       - published
 
 jobs:
-  build_wheel:
-    name: Build universal wheel
+  build:
+    name: Build universal wheel and source distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - uses: ./.github/actions/install-python-and-package
         with:
           extras-require: publishing
-
-      - name: Build wheel
-        run: python setup.py bdist_wheel
-
+      - name: Build wheel and source distribution
+        run: python -m build
       - uses: actions/upload-artifact@v3
         with:
-          path: dist/*.whl
-
-  build_sdist:
-    name: Build source distribution
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ./.github/actions/install-python-and-package
-        with:
-          extras-require: publishing
-
-      - name: Build sdist
-        run: python setup.py sdist
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: dist/*.tar.gz
-
+          path: dist/*
 
   upload_test_pypi:
-    needs: [build_wheel, build_sdist]
+    needs: [build]
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
-
       - uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 
-
   upload_pypi:
-    needs: [build_wheel, build_sdist]
+    needs: [build]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
@@ -67,7 +45,6 @@ jobs:
         with:
           name: artifact
           path: dist
-
       - uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,7 +16,7 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/actions/install-python-and-package

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ dev =
     pandoc
     myst-parser
 publishing =
+    build
     twine
     wheel
 notebooks =


### PR DESCRIPTION
Three updates in this PR:

1. Update GitHub actions versions (necessary because the old ones will soon stop working).
2. Simplify the release workflow: use the `build` module to build wheels and source distribution in one go, as recommended here: https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives
3. Streamline the release workflow: only trigger the test.pypi upload when manually running the workflow. Before, it would also trigger on releases, but this is unnecessary. This way, the test.pypi.org channel can also be used to test an upload without having to bump the version.