### PR TITLE
expose SimpleModelRunner to user

### DIFF
--- a/dianna/utils/__init__.py
+++ b/dianna/utils/__init__.py
@@ -4,5 +4,5 @@ from .misc import get_kwargs_applicable_to_function
 from .misc import move_axis
 from .misc import onnx_model_node_loader
 from .misc import to_xarray
-from .tokenizers import SpacyTokenizer
 from .onnx_runner import SimpleModelRunner
+from .tokenizers import SpacyTokenizer

--- a/dianna/utils/__init__.py
+++ b/dianna/utils/__init__.py
@@ -5,3 +5,4 @@ from .misc import move_axis
 from .misc import onnx_model_node_loader
 from .misc import to_xarray
 from .tokenizers import SpacyTokenizer
+from .onnx_runner import SimpleModelRunner


### PR DESCRIPTION
I think a user is not able to import the SimpleModelRunner at the moment. That must be a mistake. This commit exposes it to the user so they can reuse it.

I think this PR can be approved if any reviewer agrees on both questions below:
Do you agree that the class could not have been imported by a users before adding it to the __init__?

Do you agree that we want to make this part reusable?