### PR TITLE
Remove torchtext dependency

### DIFF
--- a/dianna/utils/__init__.py
+++ b/dianna/utils/__init__.py
@@ -5,4 +5,3 @@ from .misc import move_axis
 from .misc import onnx_model_node_loader
 from .misc import to_xarray
 from .onnx_runner import SimpleModelRunner
-from .tokenizers import SpacyTokenizer

--- a/dianna/utils/tokenizers.py
+++ b/dianna/utils/tokenizers.py
@@ -5,9 +5,9 @@ from typing import List
 
 try:
     from torchtext.data import get_tokenizer
-except ImportError:
+except ImportError as err:
     raise ImportError("Failed to import torchtext, please install manually or reinstall dianna with "
-                      "text support: `pip install dianna[text]`")
+                      "text support: `pip install dianna[text]`") from err
 
 
 class Tokenizer(ABC):

--- a/dianna/utils/tokenizers.py
+++ b/dianna/utils/tokenizers.py
@@ -7,7 +7,7 @@ try:
     from torchtext.data import get_tokenizer
 except ImportError:
     raise ImportError("Failed to import torchtext, please install manually or reinstall dianna with "
-                      "text support: `pip install --force-reinstall dianna[text]`")
+                      "text support: `pip install dianna[text]`")
 
 
 class Tokenizer(ABC):

--- a/dianna/utils/tokenizers.py
+++ b/dianna/utils/tokenizers.py
@@ -1,7 +1,13 @@
 from abc import ABC
 from abc import abstractmethod
 from typing import List
-from torchtext.data import get_tokenizer
+
+
+try:
+    from torchtext.data import get_tokenizer
+except ImportError:
+    raise ImportError("Failed to import torchtext, please install manually or reinstall dianna with "
+                      "text support: `pip install --force-reinstall dianna[text]`")
 
 
 class Tokenizer(ABC):

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,6 +88,8 @@ notebooks =
     torchtext
     torchvision
     ipywidgets
+text =
+    torchtext
 
 [options.packages.find]
 include = dianna, dianna.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,6 +90,7 @@ notebooks =
     ipywidgets
 text =
     torchtext
+    spacy
 
 [options.packages.find]
 include = dianna, dianna.*

--- a/tutorials/lime_text.ipynb
+++ b/tutorials/lime_text.ipynb
@@ -26,16 +26,7 @@
    "execution_count": 1,
    "id": "34b556d8-5337-44dc-8efe-14d1dff6f011",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import matplotlib.pyplot as plt\n",
@@ -46,7 +37,8 @@
     "\n",
     "import dianna\n",
     "from dianna import visualization\n",
-    "from dianna import utils"
+    "from dianna import utils\n",
+    "from dianna.utils.tokenizers import SpacyTokenizer"
    ]
   },
   {
@@ -74,54 +66,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "486540bd-2676-4dfa-bbe8-ee8aa289acd3",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Collecting en-core-web-sm==3.2.0\n",
-      "  Downloading https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl (13.9 MB)\n",
-      "     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 13.9/13.9 MB 6.9 MB/s eta 0:00:00\n",
-      "Requirement already satisfied: spacy<3.3.0,>=3.2.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from en-core-web-sm==3.2.0) (3.2.4)\n",
-      "Requirement already satisfied: wasabi<1.1.0,>=0.8.1 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (0.9.1)\n",
-      "Requirement already satisfied: typer<0.5.0,>=0.3.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (0.4.1)\n",
-      "Requirement already satisfied: setuptools in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (62.1.0)\n",
-      "Requirement already satisfied: requests<3.0.0,>=2.13.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.27.1)\n",
-      "Requirement already satisfied: blis<0.8.0,>=0.4.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (0.7.7)\n",
-      "Requirement already satisfied: packaging>=20.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (21.3)\n",
-      "Requirement already satisfied: thinc<8.1.0,>=8.0.12 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (8.0.15)\n",
-      "Requirement already satisfied: catalogue<2.1.0,>=2.0.6 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.0.7)\n",
-      "Requirement already satisfied: langcodes<4.0.0,>=3.2.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.3.0)\n",
-      "Requirement already satisfied: tqdm<5.0.0,>=4.38.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (4.64.0)\n",
-      "Requirement already satisfied: numpy>=1.15.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (1.21.6)\n",
-      "Requirement already satisfied: spacy-legacy<3.1.0,>=3.0.8 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.0.9)\n",
-      "Requirement already satisfied: preshed<3.1.0,>=3.0.2 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.0.6)\n",
-      "Requirement already satisfied: srsly<3.0.0,>=2.4.1 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.4.3)\n",
-      "Requirement already satisfied: jinja2 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.1.1)\n",
-      "Requirement already satisfied: cymem<2.1.0,>=2.0.2 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.0.6)\n",
-      "Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (1.0.6)\n",
-      "Requirement already satisfied: pathy>=0.3.5 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (0.6.1)\n",
-      "Requirement already satisfied: spacy-loggers<2.0.0,>=1.0.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (1.0.2)\n",
-      "Requirement already satisfied: click<8.1.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (8.0.4)\n",
-      "Requirement already satisfied: pydantic!=1.8,!=1.8.1,<1.9.0,>=1.7.4 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (1.8.2)\n",
-      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from packaging>=20.0->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.0.8)\n",
-      "Requirement already satisfied: smart-open<6.0.0,>=5.0.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from pathy>=0.3.5->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (5.2.1)\n",
-      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from pydantic!=1.8,!=1.8.1,<1.9.0,>=1.7.4->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (4.1.1)\n",
-      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from requests<3.0.0,>=2.13.0->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (1.26.9)\n",
-      "Requirement already satisfied: charset-normalizer~=2.0.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from requests<3.0.0,>=2.13.0->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.0.12)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from requests<3.0.0,>=2.13.0->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2021.10.8)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from requests<3.0.0,>=2.13.0->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.3)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from jinja2->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.1.1)\n",
-      "\u001b[38;5;2m✔ Download and installation successful\u001b[0m\n",
-      "You can now load the package via spacy.load('en_core_web_sm')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# ensure the tokenizer for english is available\n",
     "spacy.cli.download('en_core_web_sm')"
@@ -140,7 +90,7 @@
     "        self.vocab = Vectors(word_vectors, cache=os.path.dirname(word_vectors))\n",
     "        self.max_filter_size = max_filter_size\n",
     "        \n",
-    "        self.tokenizer =  utils.SpacyTokenizer(name='en_core_web_sm')\n",
+    "        self.tokenizer =  SpacyTokenizer(name='en_core_web_sm')\n",
     "\n",
     "    def __call__(self, sentences):\n",
     "        # ensure the input has a batch axis\n",
@@ -208,24 +158,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "7c0bfd7d-df1d-4981-b714-496bc16b9347",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[('intriguing', 3, 0.18069357117488236),\n",
-       " ('thriller', 4, 0.0701534595820949),\n",
-       " ('delectable', 1, 0.06422821484050707),\n",
-       " ('and', 2, 0.022021281288262952),\n",
-       " ('with', 6, 0.013646861780188986),\n",
-       " ('filled', 5, -0.009685493678403831),\n",
-       " ('surprises', 7, 0.004973988118338169),\n",
-       " ('A', 0, 0.002933746646157758)]"
+       "[('intriguing', 3, 0.18379392986356602),\n",
+       " ('thriller', 4, 0.07241839614499643),\n",
+       " ('delectable', 1, 0.06677609981740236),\n",
+       " ('and', 2, 0.01734695021775524),\n",
+       " ('with', 6, 0.013909200028387934),\n",
+       " ('filled', 5, -0.013094230898609081),\n",
+       " ('surprises', 7, 0.005932602337045452),\n",
+       " ('A', 0, 0.003498162477570695)]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -248,14 +198,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "0136005d-a22f-43a0-80da-4ec1f283f870",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<html><body><span style=\"background:rgba(255, 0, 0, 0.01)\">A</span> <span style=\"background:rgba(255, 0, 0, 0.28)\">delectable</span> <span style=\"background:rgba(255, 0, 0, 0.10)\">and</span> <span style=\"background:rgba(255, 0, 0, 0.80)\">intriguing</span> <span style=\"background:rgba(255, 0, 0, 0.31)\">thriller</span> <span style=\"background:rgba(0, 0, 255, 0.042881)\">filled</span> <span style=\"background:rgba(255, 0, 0, 0.06)\">with</span> <span style=\"background:rgba(255, 0, 0, 0.02)\">surprises</span></body></html>"
+       "<html><body><span style=\"background:rgba(255, 0, 0, 0.02)\">A</span> <span style=\"background:rgba(255, 0, 0, 0.29)\">delectable</span> <span style=\"background:rgba(255, 0, 0, 0.08)\">and</span> <span style=\"background:rgba(255, 0, 0, 0.80)\">intriguing</span> <span style=\"background:rgba(255, 0, 0, 0.32)\">thriller</span> <span style=\"background:rgba(0, 0, 255, 0.056995)\">filled</span> <span style=\"background:rgba(255, 0, 0, 0.06)\">with</span> <span style=\"background:rgba(255, 0, 0, 0.03)\">surprises</span></body></html>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -294,7 +244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/rise_text.ipynb
+++ b/tutorials/rise_text.ipynb
@@ -30,16 +30,7 @@
    "execution_count": 1,
    "id": "34b556d8-5337-44dc-8efe-14d1dff6f011",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import matplotlib.pyplot as plt\n",
@@ -50,7 +41,8 @@
     "\n",
     "import dianna\n",
     "from dianna import visualization\n",
-    "from dianna import utils"
+    "from dianna import utils\n",
+    "from dianna.utils.tokenizers import SpacyTokenizer"
    ]
   },
   {
@@ -78,54 +70,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "486540bd-2676-4dfa-bbe8-ee8aa289acd3",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Collecting en-core-web-sm==3.2.0\n",
-      "  Downloading https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl (13.9 MB)\n",
-      "     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 13.9/13.9 MB 8.1 MB/s eta 0:00:00\n",
-      "Requirement already satisfied: spacy<3.3.0,>=3.2.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from en-core-web-sm==3.2.0) (3.2.4)\n",
-      "Requirement already satisfied: srsly<3.0.0,>=2.4.1 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.4.3)\n",
-      "Requirement already satisfied: wasabi<1.1.0,>=0.8.1 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (0.9.1)\n",
-      "Requirement already satisfied: pydantic!=1.8,!=1.8.1,<1.9.0,>=1.7.4 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (1.8.2)\n",
-      "Requirement already satisfied: requests<3.0.0,>=2.13.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.27.1)\n",
-      "Requirement already satisfied: cymem<2.1.0,>=2.0.2 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.0.6)\n",
-      "Requirement already satisfied: packaging>=20.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (21.3)\n",
-      "Requirement already satisfied: spacy-loggers<2.0.0,>=1.0.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (1.0.2)\n",
-      "Requirement already satisfied: click<8.1.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (8.0.4)\n",
-      "Requirement already satisfied: blis<0.8.0,>=0.4.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (0.7.7)\n",
-      "Requirement already satisfied: jinja2 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.1.1)\n",
-      "Requirement already satisfied: langcodes<4.0.0,>=3.2.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.3.0)\n",
-      "Requirement already satisfied: setuptools in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (62.1.0)\n",
-      "Requirement already satisfied: thinc<8.1.0,>=8.0.12 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (8.0.15)\n",
-      "Requirement already satisfied: pathy>=0.3.5 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (0.6.1)\n",
-      "Requirement already satisfied: typer<0.5.0,>=0.3.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (0.4.1)\n",
-      "Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (1.0.6)\n",
-      "Requirement already satisfied: catalogue<2.1.0,>=2.0.6 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.0.7)\n",
-      "Requirement already satisfied: tqdm<5.0.0,>=4.38.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (4.64.0)\n",
-      "Requirement already satisfied: numpy>=1.15.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (1.21.6)\n",
-      "Requirement already satisfied: spacy-legacy<3.1.0,>=3.0.8 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.0.9)\n",
-      "Requirement already satisfied: preshed<3.1.0,>=3.0.2 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.0.6)\n",
-      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from packaging>=20.0->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.0.8)\n",
-      "Requirement already satisfied: smart-open<6.0.0,>=5.0.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from pathy>=0.3.5->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (5.2.1)\n",
-      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from pydantic!=1.8,!=1.8.1,<1.9.0,>=1.7.4->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (4.1.1)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from requests<3.0.0,>=2.13.0->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (3.3)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from requests<3.0.0,>=2.13.0->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2021.10.8)\n",
-      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from requests<3.0.0,>=2.13.0->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (1.26.9)\n",
-      "Requirement already satisfied: charset-normalizer~=2.0.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from requests<3.0.0,>=2.13.0->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.0.12)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in /opt/homebrew/Caskroom/miniforge/base/envs/dianna/lib/python3.9/site-packages (from jinja2->spacy<3.3.0,>=3.2.0->en-core-web-sm==3.2.0) (2.1.1)\n",
-      "\u001b[38;5;2m✔ Download and installation successful\u001b[0m\n",
-      "You can now load the package via spacy.load('en_core_web_sm')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# ensure the tokenizer for english is available\n",
     "spacy.cli.download('en_core_web_sm')"
@@ -144,7 +94,7 @@
     "        self.vocab = Vectors(word_vectors, cache=os.path.dirname(word_vectors))\n",
     "        self.max_filter_size = max_filter_size\n",
     "        \n",
-    "        self.tokenizer = utils.SpacyTokenizer(name='en_core_web_sm')\n",
+    "        self.tokenizer = SpacyTokenizer(name='en_core_web_sm')\n",
     "\n",
     "    def __call__(self, sentences):\n",
     "        # ensure the input has a batch axis\n",
@@ -211,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "7c0bfd7d-df1d-4981-b714-496bc16b9347",
    "metadata": {},
    "outputs": [
@@ -219,30 +169,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rise parameter p_keep was automatically determined at 0.30000000000000004\n"
+      "Rise parameter p_keep was automatically determined at 0.2\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Explaining: 100%|██████████| 10/10 [00:03<00:00,  2.99it/s]\n"
+      "Explaining: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:17<00:00,  1.72s/it]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[('A', 0, 0.7424104153116543),\n",
-       " ('delectable', 1, 0.8948592670758564),\n",
-       " ('and', 2, 0.7596694403886795),\n",
-       " ('intriguing', 3, 0.9701695909102755),\n",
-       " ('thriller', 4, 0.8438681717713672),\n",
-       " ('filled', 5, 0.7655792977412541),\n",
-       " ('with', 6, 0.8653028553724287),\n",
-       " ('surprises', 7, 0.6903305816650389)]"
+       "[('A', 0, 0.7158780014514923),\n",
+       " ('delectable', 1, 0.913871341049671),\n",
+       " ('and', 2, 0.6892129376530648),\n",
+       " ('intriguing', 3, 1.0620161551237106),\n",
+       " ('thriller', 4, 0.840078490972519),\n",
+       " ('filled', 5, 0.6051010835170746),\n",
+       " ('with', 6, 0.6926153092086315),\n",
+       " ('surprises', 7, 0.6697717276215553)]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -266,14 +216,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "0136005d-a22f-43a0-80da-4ec1f283f870",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<html><body><span style=\"background:rgba(255, 0, 0, 0.61)\">A</span> <span style=\"background:rgba(255, 0, 0, 0.74)\">delectable</span> <span style=\"background:rgba(255, 0, 0, 0.63)\">and</span> <span style=\"background:rgba(255, 0, 0, 0.80)\">intriguing</span> <span style=\"background:rgba(255, 0, 0, 0.70)\">thriller</span> <span style=\"background:rgba(255, 0, 0, 0.63)\">filled</span> <span style=\"background:rgba(255, 0, 0, 0.71)\">with</span> <span style=\"background:rgba(255, 0, 0, 0.57)\">surprises</span></body></html>"
+       "<html><body><span style=\"background:rgba(255, 0, 0, 0.54)\">A</span> <span style=\"background:rgba(255, 0, 0, 0.69)\">delectable</span> <span style=\"background:rgba(255, 0, 0, 0.52)\">and</span> <span style=\"background:rgba(255, 0, 0, 0.80)\">intriguing</span> <span style=\"background:rgba(255, 0, 0, 0.63)\">thriller</span> <span style=\"background:rgba(255, 0, 0, 0.46)\">filled</span> <span style=\"background:rgba(255, 0, 0, 0.52)\">with</span> <span style=\"background:rgba(255, 0, 0, 0.50)\">surprises</span></body></html>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"


### PR DESCRIPTION
The previous release is broken if the user does not have torchtext installed, see #357.
This PR makes torchtext optional, by not always importing the tokenizer anymore. An informative error is raised when the user tries to import a tokenizer when torchtext is not available. A dianna[text] variant is added to allow the user to automatically install the required dependencies for text-based explanations.