### PR TITLE
change p_keep autotuning behavior (fixes #380)

### DIFF
--- a/dianna/methods/rise.py
+++ b/dianna/methods/rise.py
@@ -17,7 +17,7 @@ def _predict_in_batches(masked, runner):
     batch_size = 50
     predictions = []
     for i in range(0, len(masked), batch_size):
-        current_input = masked[i:i + batch_size]
+        current_input = masked[i:min(i + batch_size, len(masked))]
         current_predictions = runner(current_input)
         predictions.append(current_predictions)
     predictions = np.concatenate(predictions)
@@ -90,7 +90,7 @@ class RISEText:
         masks = self._generate_masks(input_text.shape, p_keep, n_masks)
         masked = self._create_masked_sentences(input_text, masks, tokenizer)
         predictions = _predict_in_batches(masked, runner)
-        std_per_class = predictions.std(axis=0)  # TODO: add axis see https://github.com/dianna-ai/dianna/issues/380
+        std_per_class = predictions.std(axis=0)
         return np.max(std_per_class)
 
     def _generate_masks(self, input_shape, p_keep, n_masks):

--- a/tests/test_rise.py
+++ b/tests/test_rise.py
@@ -40,7 +40,7 @@ class RiseOnImages(TestCase):
     def test_rise_determine_p_keep_for_images(self):
         """Tests exact expected p_keep given an image and model."""
         np.random.seed(0)
-        expected_p_exact_keep = .1
+        expected_p_exact_keep = .4
         model_filename = 'tests/test_data/mnist_model.onnx'
         data = get_mnist_1_data().astype(np.float32)
 
@@ -76,7 +76,7 @@ class RiseOnText(TestCase):
     def test_rise_determine_p_keep_for_text(self):
         """Tests exact expected p_keep given a text and model."""
         np.random.seed(0)
-        expected_p_exact_keep = .5
+        expected_p_exact_keep = .7
         model_path = 'tests/test_data/movie_review_model.onnx'
         word_vector_file = 'tests/test_data/word_vectors.txt'
         runner = ModelRunner(model_path, word_vector_file, max_filter_size=5)


### PR DESCRIPTION
Fixes #380 
This bug and its fix takes some knowledge of how RISE works to review.

We have 3 behaviors to talk about: The old actual behavior (that we considered bugged) which is the code of the main branch, the old intended behavior, and the new behavior as proposed in this PR.

### Purpose of the code
Note that the ultimate goal here is to pick the best p_keep. For this we calculate a score for every p_keep. 
We do this by masking instances with N random masks and make predictions for all. The result is a matrix of N by C (`number of classes`). We then calculate a score based on those and pick the p_keep with the highest score. This was the same for all 3 behaviors. The way the score was calculated was different.

#### Old intended behavior
The old intended behavior was as follows. For each of the classes we take the std over all N predictions. We then take the mean over all classes and end up with score that is a single scalar. 

#### Old actual behavior
For whatever reason, intentional or not, the old actual behavior was different. Of the `NxC` predictions we took the highest class of every N rows which resulted in a vector of length N. We then took the std of that, which is peculiar as the vector now contains predictions potentially belonging to varying classes. The result is a scalar, but we took the mean of that anyway, which is a no-op, indicating that we didn't really know what we were doing. The result was the score.

I didn't like the the old actual behavior because of mixing predictions from various classes and then doing statistics on that mix doesn't seem to make sense and I wouldn't know how to reason about it and pick a preferred p_keep based on that. I didn't like the old intended behavior either because it takes into account the stds of all classes. We are mostly interested in the top class or classes. In the case of a model with many classes (eg. ImageNet) the influence of the scores on irrelevant classes could be great and is unpredictable.

#### New behavior
Therefore, the new behavior that this PR proposes:
We take the std over all N rows and end up with a vector of length C, containing the std per class. We then take the max value of this, which we use as the score. 

Reasoning for the new behavior: Low scoring classes are bound to have low stds. Therefore the greatest std, belongs probably to the (or one of the) highest scoring classes. Alternatively, we could take the std of the highest scoring class instead for each of the N rows. This could be fine, but that would ignore all changes in probabilities, even of potentially important ones like other top classes.

Note that, because I changed the behavior, I also changed the tests.