### PR TITLE
fix 1 doi and add 5 new dois (fix #394)

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -375,7 +375,7 @@
   volume    = {abs/1812.09244},
   year      = {2018},
   url       = {http://arxiv.org/abs/1812.09244},
-  doi       = {10.18653/v1/p19-1647}
+  doi       = {10.18653/v1/p19-1647},
   eprinttype = {arXiv},
   eprint    = {1812.09244},
   timestamp = {Wed, 02 Jan 2019 14:40:18 +0100},

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -410,7 +410,7 @@
   url       = {http://arxiv.org/abs/1706.03815},
   eprinttype = {arXiv},
   eprint    = {1706.03815},
-  doi       = {10.18653/v1/k17-1037}
+  doi       = {10.18653/v1/k17-1037},
   timestamp = {Mon, 13 Aug 2018 16:46:47 +0200},
   biburl    = {https://dblp.org/rec/journals/corr/AlishahiBC17.bib},
   bibsource = {dblp computer science bibliography, https://dblp.org}
@@ -441,7 +441,7 @@
   url       = {https://arxiv.org/abs/2104.13225},
   eprinttype = {arXiv},
   eprint    = {2104.13225},
-  doi       = {10.1613/jair.1.12967}
+  doi       = {10.1613/jair.1.12967},
   timestamp = {Tue, 04 May 2021 15:12:43 +0200},
   biburl    = {https://dblp.org/rec/journals/corr/abs-2104-13225.bib},
   bibsource = {dblp computer science bibliography, https://dblp.org}

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -81,6 +81,7 @@
   volume    = {abs/1602.04938},
   year      = {2016},
   url       = {http://arxiv.org/abs/1602.04938},
+  doi       = {10.18653/v1/n16-3020},
   eprinttype = {arXiv},
   eprint    = {1602.04938},
   timestamp = {Mon, 13 Aug 2018 16:49:09 +0200},
@@ -131,7 +132,7 @@
 	volume = {122},
 	issn = {0148-2963},
 	url = {https://www.sciencedirect.com/science/article/pii/S014829632030583X},
-	doi = {https://doi.org/10.1016/j.jbusres.2020.09.009},
+	doi = {10.1016/j.jbusres.2020.09.009},
     pages = {502--517},
 	journaltitle = {Journal of Business Research},
 	author = {Toorajipour, Reza and Sohrabpour, Vahid and Nazarpour, Ali and Oghazi, Pejvak and Fischl, Maria},
@@ -342,7 +343,8 @@
   title = {Leafsnap: A Computer Vision System for Automatic Plant Species Identification},
   booktitle = {The 12th European Conference on Computer Vision (ECCV)},
   month = {October},
-  year = {2012}
+  year = {2012},
+  doi = {10.1007/978-3-642-33709-3_36}
 }
 
 @inproceedings{socher-etal-2013-recursive,
@@ -373,6 +375,7 @@
   volume    = {abs/1812.09244},
   year      = {2018},
   url       = {http://arxiv.org/abs/1812.09244},
+  doi       = {10.18653/v1/p19-1647}
   eprinttype = {arXiv},
   eprint    = {1812.09244},
   timestamp = {Wed, 02 Jan 2019 14:40:18 +0100},
@@ -407,6 +410,7 @@
   url       = {http://arxiv.org/abs/1706.03815},
   eprinttype = {arXiv},
   eprint    = {1706.03815},
+  doi       = {10.18653/v1/k17-1037}
   timestamp = {Mon, 13 Aug 2018 16:46:47 +0200},
   biburl    = {https://dblp.org/rec/journals/corr/AlishahiBC17.bib},
   bibsource = {dblp computer science bibliography, https://dblp.org}
@@ -437,6 +441,7 @@
   url       = {https://arxiv.org/abs/2104.13225},
   eprinttype = {arXiv},
   eprint    = {2104.13225},
+  doi       = {10.1613/jair.1.12967}
   timestamp = {Tue, 04 May 2021 15:12:43 +0200},
   biburl    = {https://dblp.org/rec/journals/corr/abs-2104-13225.bib},
   bibsource = {dblp computer science bibliography, https://dblp.org}


### PR DESCRIPTION
Close #394.
This fixes one doi was incorrect and adds a couple of dois to references without a doi, as suggested by the JOSS bot.