### PR TITLE
Make axis labels optional

### DIFF
--- a/dianna/methods/kernelshap.py
+++ b/dianna/methods/kernelshap.py
@@ -151,7 +151,7 @@ class KERNELSHAPImage:
         axis_label_names = self.axis_labels.values() if isinstance(self.axis_labels, dict) else self.axis_labels
         if not axis_label_names:
             channels_axis_index = utils.locate_channels_axis(input_data.shape)
-            self.axis_labels = {'channels': channels_axis_index}
+            self.axis_labels = {channels_axis_index: 'channels'}
         elif 'channels' not in axis_label_names:
             raise ValueError("When providing axis_labels it is required to provide the location"
                              " of the channels axis")

--- a/dianna/methods/kernelshap.py
+++ b/dianna/methods/kernelshap.py
@@ -7,8 +7,6 @@ from dianna import utils
 
 class KERNELSHAPImage:
     """Kernel SHAP implementation based on shap https://github.com/slundberg/shap."""
-    # axis labels required to be present in input image data
-    required_labels = ('channels', )
 
     def __init__(self, axis_labels=None, preprocess_function=None):
         """Kernelshap initializer.
@@ -149,8 +147,16 @@ class KERNELSHAPImage:
         Returns:
             transformed input data
         """
-        input_data = utils.to_xarray(
-            input_data, self.axis_labels, KERNELSHAPImage.required_labels)
+        # automatically determine the location of the channels axis if no axis_labels were provided
+        axis_label_names = self.axis_labels.values() if isinstance(self.axis_labels, dict) else self.axis_labels
+        if not axis_label_names:
+            channels_axis_index = utils.locate_channels_axis(input_data.shape)
+            self.axis_labels = {'channels': channels_axis_index}
+        elif 'channels' not in axis_label_names:
+            raise ValueError("When providing axis_labels it is required to provide the location"
+                             " of the channels axis")
+
+        input_data = utils.to_xarray(input_data, self.axis_labels)
         # ensure channels axis is last and keep track of where it was so we can move it back
         self.channels_axis_index = input_data.dims.index('channels')
         input_data = utils.move_axis(input_data, 'channels', -1)

--- a/dianna/methods/lime.py
+++ b/dianna/methods/lime.py
@@ -205,7 +205,7 @@ class LIMEImage:
         axis_label_names = self.axis_labels.values() if isinstance(self.axis_labels, dict) else self.axis_labels
         if not axis_label_names:
             channels_axis_index = utils.locate_channels_axis(input_data.shape)
-            self.axis_labels = {'channels': channels_axis_index}
+            self.axis_labels = {channels_axis_index: 'channels'}
         elif 'channels' not in axis_label_names:
             raise ValueError("When providing axis_labels it is required to provide the location"
                              " of the channels axis")

--- a/dianna/methods/lime.py
+++ b/dianna/methods/lime.py
@@ -109,8 +109,6 @@ class LIMEText:
 
 class LIMEImage:
     """Wrapper around the LIME explainer implemented by Marco Tulio Correia Ribeiro (https://github.com/marcotcr/lime)."""
-    # axis labels required to be present in input image data
-    required_labels = ('channels', )
 
     def __init__(self,
                  kernel_width=25,
@@ -203,7 +201,16 @@ class LIMEImage:
         Returns:
             transformed input data, preprocessing function to use with utils.get_function()
         """
-        input_data = utils.to_xarray(input_data, self.axis_labels, LIMEImage.required_labels)
+        # automatically determine the location of the channels axis if no axis_labels were provided
+        axis_label_names = self.axis_labels.values() if isinstance(self.axis_labels, dict) else self.axis_labels
+        if not axis_label_names:
+            channels_axis_index = utils.locate_channels_axis(input_data.shape)
+            self.axis_labels = {'channels': channels_axis_index}
+        elif 'channels' not in axis_label_names:
+            raise ValueError("When providing axis_labels it is required to provide the location"
+                             " of the channels axis")
+
+        input_data = utils.to_xarray(input_data, self.axis_labels)
         # ensure channels axis is last and keep track of where it was so we can move it back
         channels_axis_index = input_data.dims.index('channels')
         input_data = utils.move_axis(input_data, 'channels', -1)

--- a/dianna/methods/rise.py
+++ b/dianna/methods/rise.py
@@ -167,7 +167,7 @@ class RISEImage:
         axis_label_names = self.axis_labels.values() if isinstance(self.axis_labels, dict) else self.axis_labels
         if not axis_label_names:
             channels_axis_index = utils.locate_channels_axis(input_data.shape)
-            self.axis_labels = {'channels': channels_axis_index}
+            self.axis_labels = {channels_axis_index: 'channels'}
         elif 'channels' not in axis_label_names:
             raise ValueError("When providing axis_labels it is required to provide the location"
                              " of the channels axis")

--- a/dianna/methods/rise.py
+++ b/dianna/methods/rise.py
@@ -126,9 +126,6 @@ class RISEText:
 class RISEImage:
     """RISE implementation for images based on https://github.com/eclique/RISE/blob/master/Easy_start.ipynb."""
 
-    # axis labels required to be present in input image data
-    required_labels = ('channels',)
-
     def __init__(self, n_masks=1000, feature_res=8, p_keep=None,
                  axis_labels=None, preprocess_function=None):
         """RISE initializer.
@@ -166,8 +163,17 @@ class RISEImage:
         Returns:
             Explanation heatmap for each class (np.ndarray).
         """
+        # automatically determine the location of the channels axis if no axis_labels were provided
+        axis_label_names = self.axis_labels.values() if isinstance(self.axis_labels, dict) else self.axis_labels
+        if not axis_label_names:
+            channels_axis_index = utils.locate_channels_axis(input_data.shape)
+            self.axis_labels = {'channels': channels_axis_index}
+        elif 'channels' not in axis_label_names:
+            raise ValueError("When providing axis_labels it is required to provide the location"
+                             " of the channels axis")
+
         # convert data to xarray
-        input_data = utils.to_xarray(input_data, self.axis_labels, RISEImage.required_labels)
+        input_data = utils.to_xarray(input_data, self.axis_labels)
         # add batch axis as first axis
         input_data = input_data.expand_dims('batch', 0)
         input_data, full_preprocess_function = self._prepare_image_data(input_data)

--- a/dianna/utils/__init__.py
+++ b/dianna/utils/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa: F401
 from .misc import get_function
 from .misc import get_kwargs_applicable_to_function
+from .misc import locate_channels_axis
 from .misc import move_axis
 from .misc import onnx_model_node_loader
 from .misc import to_xarray

--- a/dianna/utils/misc.py
+++ b/dianna/utils/misc.py
@@ -141,7 +141,7 @@ def locate_channels_axis(data_shape):
                              f" because both the first and last axis have size {size}. Please provide the"
                              f" location of the channels axis using the axis_labels argument")
         # if one of the two is true, we return the corresponding axis location
-        elif channels_first:
+        if channels_first:
             channels_axis_index = 0
             break
         elif channels_last:

--- a/dianna/utils/misc.py
+++ b/dianna/utils/misc.py
@@ -144,7 +144,7 @@ def locate_channels_axis(data_shape):
         if channels_first:
             channels_axis_index = 0
             break
-        elif channels_last:
+        if channels_last:
             channels_axis_index = -1
             break
 

--- a/dianna/utils/misc.py
+++ b/dianna/utils/misc.py
@@ -112,3 +112,18 @@ def onnx_model_node_loader(model_path):
     dtype_input_node = tf_model_rep.tensor_dict[f'{label_input_node}'].dtype
 
     return onnx_model, dtype_input_node, label_output_node
+
+
+def locate_channels_axis(data_shape):
+    """Determine location of (colour) channels axis in input data.
+
+    The channels axis is assumed to have size 3 (for colour images) or 1
+    (for grayscale images). An error is raised if this is not the case.
+
+    Args:
+        data_shape (tuple): The shape of one data item, without a batch axis
+
+    Returns:
+        0 or -1 indicating the index of the channels axis.
+    """
+    raise NotImplementedError()

--- a/dianna/utils/misc.py
+++ b/dianna/utils/misc.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 
 
 def get_function(model_or_function, preprocess_function=None):
@@ -115,10 +116,11 @@ def onnx_model_node_loader(model_path):
 
 
 def locate_channels_axis(data_shape):
-    """Determine location of (colour) channels axis in input data.
+    """Determine index of (colour) channels axis in input data.
 
     The channels axis is assumed to have size 3 (for colour images) or 1
-    (for grayscale images). An error is raised if this is not the case.
+    (for greyscale images). An error is raised if this is not the case or the channels
+    axis could not be found.
 
     Args:
         data_shape (tuple): The shape of one data item, without a batch axis
@@ -126,4 +128,31 @@ def locate_channels_axis(data_shape):
     Returns:
         0 or -1 indicating the index of the channels axis.
     """
-    raise NotImplementedError()
+    # check for channels axis of size 1 or 3
+    channels_axis_index = None
+    sizes = (1, 3)
+    for size in sizes:
+        # check if the first or last axis has the given size
+        channels_first = data_shape[0] == size
+        channels_last = data_shape[-1] == size
+        # if both are true, we cannot determine the location of the channels axis
+        if channels_first and channels_last:
+            raise ValueError(f"Could not automatically determine the location of the colour channels axis"
+                             f" because both the first and last axis have size {size}. Please provide the"
+                             f" location of the channels axis using the axis_labels argument")
+        # if one of the two is true, we return the corresponding axis location
+        elif channels_first:
+            channels_axis_index = 0
+            break
+        elif channels_last:
+            channels_axis_index = -1
+            break
+
+    # if channels_axis_index is still None, the location could not be determined
+    if channels_axis_index is None:
+        raise ValueError("Could not automatically determine location of the colour channels axis."
+                         " Please provide the location of the channels axis using the axis_labels argument")
+    warnings.warn(f"The index of the colour channels axis in the input data was automatically determined"
+                  f" to be {channels_axis_index}. Use the axis_labels to manually specify the index of"
+                  f" the channels axis if this is incorrect.")
+    return channels_axis_index

--- a/tests/test_kernelshap.py
+++ b/tests/test_kernelshap.py
@@ -52,8 +52,7 @@ class ShapOnImages(TestCase):
         input_data = np.random.random((1, 28, 28))
         onnx_model_path = "./tests/test_data/mnist_model.onnx"
         n_segments = 50
-        axis_labels = ('channels', 'height', 'width')
-        explainer = KERNELSHAPImage(axis_labels=axis_labels)
+        explainer = KERNELSHAPImage()
         shap_values, _ = explainer.explain(
             onnx_model_path,
             input_data,

--- a/tests/test_lime.py
+++ b/tests/test_lime.py
@@ -14,10 +14,9 @@ class LimeOnImages(TestCase):
         """Test if lime runs and outputs are correct given some data and a model function."""
         np.random.seed(42)
         input_data = np.random.random((224, 224, 3))
-        labels = ('y', 'x', 'channels')
         heatmap_expected = np.load('tests/test_data/heatmap_lime_function.npy')
 
-        explainer = LIMEImage(random_state=42, axis_labels=labels)
+        explainer = LIMEImage(random_state=42)
         heatmap = explainer.explain(run_model, input_data, num_samples=100)
 
         assert heatmap[0].shape == input_data.shape[:2]

--- a/tests/test_rise.py
+++ b/tests/test_rise.py
@@ -15,7 +15,6 @@ class RiseOnImages(TestCase):
     def test_rise_function(self):
         """Test if rise runs and outputs the correct shape given some data and a model function."""
         input_data = np.random.random((224, 224, 3))
-        # y and x axis labels are not actually mandatory for this test
         axis_labels = ['y', 'x', 'channels']
 
         heatmaps = dianna.explain_image(run_model, input_data, method="RISE", axis_labels=axis_labels, n_masks=200, p_keep=.5)
@@ -28,10 +27,8 @@ class RiseOnImages(TestCase):
         """Test if rise runs and outputs the correct shape given some data and a model file."""
         model_filename = 'tests/test_data/mnist_model.onnx'
         input_data = generate_data(batch_size=1).astype(np.float32)[0]
-        # y and x axis labels are not actually mandatory for this test
-        axis_labels = ['channels', 'y', 'x']
 
-        heatmaps = dianna.explain_image(model_filename, input_data, method="RISE", axis_labels=axis_labels, n_masks=200, p_keep=.5)
+        heatmaps = dianna.explain_image(model_filename, input_data, method="RISE", n_masks=200, p_keep=.5)
         heatmaps_expected = np.load('tests/test_data/heatmap_rise_filename.npy')
 
         assert heatmaps[0].shape == input_data.shape[1:]


### PR DESCRIPTION
This PR is an attempt at making the axis_labels argument optional. The only required label left was the colour channels index. A new utils function is added that attempts to automatically determine the location of the channels axis. This does require a few assumptions:
- The channels axis has a size of either 3 (RGB) or 1 (greyscale)
- The channels axis is either the first or the last axis

When we can't find the channels axis, we raise an error and tell the user to use axis_labels.
Even if we do find it, we give a warning as we have no way of knowing for sure we correctly identified the channels axis.
I'm not sure always giving a warning is the best solution, other suggestions are more than welcome.

Note: I've also modified a few tests to make sure that for each method, there is at least one test that uses new functionality.

Some related issues that should be closed by this:
Closes #222 
Closes #320 (because we no longer use the required_labels option, so the user will not run into this error message anymore).