### PR TITLE
Ignore build directory when running prospector

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -11,6 +11,7 @@ member-warnings: false
 
 ignore-paths:
   - docs
+  - build
 
 pyroma:
     run: true


### PR DESCRIPTION
Each linting issue is listed twice in our CI, see e.g. https://github.com/dianna-ai/dianna/actions/runs/3524834941/jobs/5910769814

This PR fixes that by removing the build directory from prospector