### PR TITLE
update test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ For detailed information on using specific DIANNA functions, please visit the [d
 
 If you want to contribute to the development of DIANNA,
 have a look at the [contribution guidelines](https://dianna.readthedocs.io/en/latest/CONTRIBUTING.html).
+See our [developer documentation](developer_info.rst) for information on developer installation, running tests, generating documentation, versioning and making a release.
 
 ## How to cite us 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5592607.svg)](https://zenodo.org/record/5592607)

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ For detailed information on using specific DIANNA functions, please visit the [d
 
 If you want to contribute to the development of DIANNA,
 have a look at the [contribution guidelines](https://dianna.readthedocs.io/en/latest/CONTRIBUTING.html).
-See our [developer documentation](developer_info.rst) for information on developer installation, running tests, generating documentation, versioning and making a release.
+See our [developer documentation](docs/developer_info.rst) for information on developer installation, running tests, generating documentation, versioning and making a release.
 
 ## How to cite us 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5592607.svg)](https://zenodo.org/record/5592607)

--- a/docs/developer_info.rst
+++ b/docs/developer_info.rst
@@ -71,7 +71,7 @@ Running the tests
 There are two ways to run tests.
 
 The first way requires an activated virtual environment with the
-development tools installed:
+development tools installed run the following from the root directory of this repository:
 
 .. code:: shell
 

--- a/docs/developer_info.rst
+++ b/docs/developer_info.rst
@@ -33,10 +33,8 @@ Dependencies and Package management
 DIANNA aims to support all Python 3 minor versions that are still
 actively maintained, currently:
 
--  3.7
--  3.8
--  3.9
--  3.10 is still missing pending the availibility of `onnxruntime` in 3.10.
+.. image:: https://img.shields.io/pypi/pyversions/dianna
+   :target: https://pypi.python.org/project/dianna/
 
 Add or remove Python versions based on availability of dependencies in
 all versions. See `the

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ install_requires =
 [options.extras_require]
 dev =
     bump2version
-    prospector[with_pyroma]
+    prospector[with_pyroma]==1.7.7  # last version that works, see https://github.com/PyCQA/prospector/issues/545
     pylint==2.15.6
     isort
     pytest


### PR DESCRIPTION
Fixes #381. Adds link to already existing but hard to find developer documentation. This contains the requested test documentation. Also updates the developer documentation with respect to the supported python versions. 