### PR TITLE
make label a required argument (Fixes #131)

### DIFF
--- a/dashboard/callbacks.py
+++ b/dashboard/callbacks.py
@@ -163,10 +163,10 @@ def global_store_i(method_sel, model_path, image_test, labels=list(range(2)),
     elif method_sel == "KernelSHAP":
         relevances = dianna.explain_image(
             model_path, image_test,
+            labels=labels,
             method=method_sel, nsamples=n_samples,
             background=background, n_segments=n_segments, sigma=sigma,
             axis_labels=axis_labels)
-
     else:
         relevances = dianna.explain_image(
             model_path, image_test * 256, 'LIME',

--- a/dianna/__init__.py
+++ b/dianna/__init__.py
@@ -33,7 +33,7 @@ __email__ = "dianna-ai@esciencecenter.nl"
 __version__ = "0.6.0"
 
 
-def explain_image(model_or_function, input_data, method, labels=(1,), **kwargs):
+def explain_image(model_or_function, input_data, method, labels, **kwargs):
     """
     Explain an image (input_data) given a model and a chosen method.
 
@@ -42,7 +42,7 @@ def explain_image(model_or_function, input_data, method, labels=(1,), **kwargs):
                                              the path to a ONNX model on disk.
         input_data (np.ndarray): Image data to be explained
         method (string): One of the supported methods: RISE, LIME or KernelSHAP
-        labels (tuple): Labels to be explained
+        labels (Iterable(int)): Labels to be explained
 
     Returns:
         One heatmap (2D array) per class.
@@ -56,7 +56,7 @@ def explain_image(model_or_function, input_data, method, labels=(1,), **kwargs):
     return explainer.explain(model_or_function, input_data, labels, **explain_image_kwargs)
 
 
-def explain_text(model_or_function, input_text, tokenizer, method, labels=(1,), **kwargs):
+def explain_text(model_or_function, input_text, tokenizer, method, labels, **kwargs):
     """
     Explain text (input_text) given a model and a chosen method.
 
@@ -66,7 +66,7 @@ def explain_text(model_or_function, input_text, tokenizer, method, labels=(1,), 
         input_text (string): Text to be explained
         tokenizer : Tokenizer class with tokenize and convert_tokens_to_string methods, and mask_token attribute
         method (string): One of the supported methods: RISE or LIME
-        labels (tuple): Labels to be explained
+        labels (Iterable(int)): Labels to be explained
 
     Returns:
         List of (word, index of word in raw text, importance for target class) tuples.

--- a/dianna/methods/kernelshap.py
+++ b/dianna/methods/kernelshap.py
@@ -62,7 +62,7 @@ class KERNELSHAPImage:
         self,
         model,
         input_data,
-        labels=(0,),
+        labels,
         nsamples="auto",
         background=None,
         n_segments=100,
@@ -84,7 +84,7 @@ class KERNELSHAPImage:
                                      example. The input dimension must be
                                      [batch, height, width, color_channels] or
                                      [batch, color_channels, height, width] (see axis_labels)
-            labels (tuple): Indices of classes to be explained
+            labels (Iterable(int)): Indices of classes to be explained
             nsamples ("auto" or int): Number of times to re-evaluate the model when
                                       explaining each prediction. More samples lead
                                       to lower variance estimates of the SHAP values.

--- a/dianna/methods/lime.py
+++ b/dianna/methods/lime.py
@@ -52,7 +52,7 @@ class LIMEText:
     def explain(self,
                 model_or_function,
                 input_text,
-                labels=(0,),
+                labels,
                 tokenizer=None,
                 top_labels=None,
                 num_features=10,
@@ -67,7 +67,7 @@ class LIMEText:
                                                  the path to a ONNX model on disk.
             tokenizer : Tokenizer class with tokenize and convert_tokens_to_string methods, and mask_token attribute
             input_text (np.ndarray): Data to be explained
-            labels ([int], optional): Iterable of indices of class to be explained
+            labels (Iterable(int)): Iterable of indices of class to be explained
 
         Other keyword arguments: see the LIME documentation for LimeTextExplainer.explain_instance:
         https://lime-ml.readthedocs.io/en/latest/lime.html#lime.lime_text.LimeTextExplainer.explain_instance.
@@ -145,7 +145,7 @@ class LIMEImage:
     def explain(self,
                 model_or_function,
                 input_data,
-                labels=(1,),
+                labels,
                 top_labels=None,
                 num_features=10,
                 num_samples=5000,
@@ -161,7 +161,7 @@ class LIMEImage:
                                                  the path to a ONNX model on disk.
             input_data (np.ndarray): Data to be explained. Must be an "RGB image", i.e. with values in
                                      the [0,255] range.
-            labels (tuple): Indices of classes to be explained
+            labels (Iterable(int)): Indices of classes to be explained
         Other keyword arguments: see the LIME documentation for LimeImageExplainer.explain_instance and
         ImageExplanation.get_image_and_mask:
 

--- a/dianna/methods/rise.py
+++ b/dianna/methods/rise.py
@@ -44,7 +44,7 @@ class RISEText:
         self.masks = None
         self.predictions = None
 
-    def explain(self, model_or_function, input_text, labels=(0,), tokenizer=None, batch_size=100):
+    def explain(self, model_or_function, input_text, labels, tokenizer=None, batch_size=100):
         """Runs the RISE explainer on text.
 
            The model will be called with masked versions of the input text.
@@ -54,7 +54,7 @@ class RISEText:
                                                  the path to a ONNX model on disk.
             input_text (np.ndarray): Text to be explained
             tokenizer: Tokenizer class with tokenize and convert_tokens_to_string methods, and mask_token attribute
-            labels (list(int)): Labels to be explained
+            labels (Iterable(int)): Labels to be explained
             batch_size (int): Batch size to use for running the model.
 
         Returns:
@@ -147,7 +147,7 @@ class RISEImage:
         self.predictions = None
         self.axis_labels = axis_labels if axis_labels is not None else []
 
-    def explain(self, model_or_function, input_data, labels=None, batch_size=100):
+    def explain(self, model_or_function, input_data, labels, batch_size=100):
         """Runs the RISE explainer on images.
 
            The model will be called with masked images,
@@ -158,7 +158,7 @@ class RISEImage:
                                                  the path to a ONNX model on disk.
             input_data (np.ndarray): Image to be explained
             batch_size (int): Batch size to use for running the model.
-            labels (tuple): Labels to be explained
+            labels (Iterable(int)): Labels to be explained
 
         Returns:
             Explanation heatmap for each class (np.ndarray).

--- a/tests/test_common_usage.py
+++ b/tests/test_common_usage.py
@@ -10,6 +10,6 @@ labels = [0, 1]
 
 
 def test_common_RISE_pipeline():  # noqa: N802 ignore case
-    heatmap = dianna.explain_image(run_model, input_data, labels=labels, method="RISE", axis_labels=axis_labels)[0]
+    heatmap = dianna.explain_image(run_model, input_data, "RISE",  labels, axis_labels=axis_labels)[0]
     dianna.visualization.plot_image(heatmap, show_plot=False)
     dianna.visualization.plot_image(heatmap, original_data=input_data[0], show_plot=False)

--- a/tests/test_common_usage.py
+++ b/tests/test_common_usage.py
@@ -1,14 +1,15 @@
 import numpy as np
+
 import dianna
 import dianna.visualization
 from tests.utils import run_model
 
-
 input_data = np.random.random((224, 224, 3))
 axis_labels = {-1: 'channels'}
+labels = [0, 1]
 
 
 def test_common_RISE_pipeline():  # noqa: N802 ignore case
-    heatmap = dianna.explain_image(run_model, input_data, method="RISE", axis_labels=axis_labels)[0]
+    heatmap = dianna.explain_image(run_model, input_data, labels=labels, method="RISE", axis_labels=axis_labels)[0]
     dianna.visualization.plot_image(heatmap, show_plot=False)
     dianna.visualization.plot_image(heatmap, original_data=input_data[0], show_plot=False)

--- a/tests/test_kernelshap.py
+++ b/tests/test_kernelshap.py
@@ -53,9 +53,11 @@ class ShapOnImages(TestCase):
         onnx_model_path = "./tests/test_data/mnist_model.onnx"
         n_segments = 50
         explainer = KERNELSHAPImage()
+        labels = [0]
         shap_values, _ = explainer.explain(
             onnx_model_path,
             input_data,
+            labels,
             nsamples=1000,
             background=0,
             n_segments=n_segments,

--- a/tests/test_lime.py
+++ b/tests/test_lime.py
@@ -15,9 +15,10 @@ class LimeOnImages(TestCase):
         np.random.seed(42)
         input_data = np.random.random((224, 224, 3))
         heatmap_expected = np.load('tests/test_data/heatmap_lime_function.npy')
+        labels = [1]
 
         explainer = LIMEImage(random_state=42)
-        heatmap = explainer.explain(run_model, input_data, num_samples=100)
+        heatmap = explainer.explain(run_model, input_data, labels, num_samples=100)
 
         assert heatmap[0].shape == input_data.shape[:2]
         assert np.allclose(heatmap, heatmap_expected, atol=1e-5)
@@ -27,10 +28,11 @@ class LimeOnImages(TestCase):
         np.random.seed(42)
         model_filename = 'tests/test_data/mnist_model.onnx'
         input_data = generate_data(batch_size=1)[0].astype(np.float32)
-        labels = ('channels', 'y', 'x')
+        axis_labels = ('channels', 'y', 'x')
+        labels = [1]
 
-        heatmap = dianna.explain_image(model_filename, input_data, method="LIME", random_state=42,
-                                       axis_labels=labels)
+        heatmap = dianna.explain_image(model_filename, input_data, method="LIME", labels=labels, random_state=42,
+                                       axis_labels=axis_labels)
 
         heatmap_expected = np.load('tests/test_data/heatmap_lime_filename.npy')
         assert heatmap[0].shape == input_data[0].shape

--- a/tests/test_rise.py
+++ b/tests/test_rise.py
@@ -16,9 +16,10 @@ class RiseOnImages(TestCase):
         """Test if rise runs and outputs the correct shape given some data and a model function."""
         input_data = np.random.random((224, 224, 3))
         axis_labels = ['y', 'x', 'channels']
-
-        heatmaps = dianna.explain_image(run_model, input_data, method="RISE", axis_labels=axis_labels, n_masks=200, p_keep=.5)
+        labels = [1]
         heatmaps_expected = np.load('tests/test_data/heatmap_rise_function.npy')
+
+        heatmaps = dianna.explain_image(run_model, input_data, "RISE", labels, axis_labels=axis_labels, n_masks=200, p_keep=.5)
 
         assert heatmaps[0].shape == input_data.shape[:2]
         assert np.allclose(heatmaps, heatmaps_expected, atol=1e-5)
@@ -27,11 +28,13 @@ class RiseOnImages(TestCase):
         """Test if rise runs and outputs the correct shape given some data and a model file."""
         model_filename = 'tests/test_data/mnist_model.onnx'
         input_data = generate_data(batch_size=1).astype(np.float32)[0]
-
-        heatmaps = dianna.explain_image(model_filename, input_data, method="RISE", n_masks=200, p_keep=.5)
         heatmaps_expected = np.load('tests/test_data/heatmap_rise_filename.npy')
+        labels = [1]
+
+        heatmaps = dianna.explain_image(model_filename, input_data, "RISE", labels, n_masks=200, p_keep=.5)
 
         assert heatmaps[0].shape == input_data.shape[1:]
+        print(heatmaps_expected.shape)
         assert np.allclose(heatmaps, heatmaps_expected, atol=1e-5)
 
     def test_rise_determine_p_keep_for_images(self):

--- a/tutorials/demo.ipynb
+++ b/tutorials/demo.ipynb
@@ -2,7 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "<img width=\"150\" alt=\"Logo_ER10\" src=\"https://user-images.githubusercontent.com/3244249/151994514-b584b984-a148-4ade-80ee-0f88b0aefa45.png\">\n",
     "\n",
@@ -11,7 +15,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Libraries"
    ]
@@ -19,7 +27,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -39,21 +51,33 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Model Interpretation for Pretrained Binary MNIST Model "
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Loads pretrained binary MNIST model and the image to be explained."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Load saved binary MNIST data."
    ]
@@ -61,7 +85,11 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# load dataset\n",
@@ -73,7 +101,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Load the pretrained binary MNIST model."
    ]
@@ -81,7 +113,11 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Load saved onnx model\n",
@@ -93,7 +129,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Print class and image of a single instance in the test data for preview."
    ]
@@ -101,7 +141,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -112,9 +156,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "<matplotlib.image.AxesImage at 0x12d8fb100>"
-      ]
+      "text/plain": "<matplotlib.image.AxesImage at 0x14c48e233d0>"
      },
      "execution_count": 4,
      "metadata": {},
@@ -122,10 +164,8 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Z1A+gAAAACXBIWXMAAAsTAAALEwEAmpwYAAANq0lEQVR4nO3db6xU9Z3H8c9HFp6gRsRowJotEGNcjesfYkjERW3auEpUHlQhcXUj5vqnJm1ckjUssSSmCW62bnyEuUSE3bA2jdBIaiM1iLqIMeCfBRRb0bDthRuQoHKJJl3kuw/uobnFO2cuM2fmDHzfr2QyM+c7Z843Ez6cM/M75/4cEQJw+juj7gYAdAdhB5Ig7EAShB1IgrADSfxVNzdmm5/+gQ6LCI+2vK09u+2bbf/O9m7bj7XzXgA6y62Os9seJ+n3kr4vaUDSVkkLIuLDknXYswMd1ok9+7WSdkfEpxHxJ0m/kHR7G+8HoIPaCfuFkv444vlAsewv2O6zvc32tja2BaBN7fxAN9qhwrcO0yOiX1K/xGE8UKd29uwDki4a8fw7kva11w6ATmkn7FslXWx7mu0JkuZLWl9NWwCq1vJhfEQctf2IpA2SxklaGREfVNYZgEq1PPTW0sb4zg50XEdOqgFw6iDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IImuTtmMzpg9e3bD2ltvvVW67iWXXFJanzt3bmn91ltvLa2/9NJLpfUyW7ZsKa1v3ry55ffOiD07kARhB5Ig7EAShB1IgrADSRB2IAnCDiTBLK494Oyzzy6tr1mzprR+0003Nax9/fXXpetOmDChtH7mmWeW1jupWe9fffVVaf2hhx5qWHvhhRda6ulU0GgW17ZOqrG9R9KQpG8kHY2Ime28H4DOqeIMuhsj4mAF7wOgg/jODiTRbthD0m9tv2O7b7QX2O6zvc32tja3BaAN7R7GXxcR+2yfL+kV2x9FxBsjXxAR/ZL6JX6gA+rU1p49IvYV9wck/UrStVU0BaB6LYfd9kTbZx1/LOkHknZW1RiAarU8zm57uob35tLw14H/ioifNVmHw/hRLF++vLT+wAMPdGzbu3btKq1/9tlnpfXDhw+3vG171OHgP2t2rXwzQ0NDDWvXX3996brbt29va9t1qnycPSI+lfS3LXcEoKsYegOSIOxAEoQdSIKwA0kQdiAJLnHtgssuu6y0/tprr5XWJ0+eXFofGBhoWLvnnntK1929e3dp/YsvviitHzlypLRe5owzyvc1jz/+eGl9yZIlpfVx48Y1rK1bt6503fvvv7+0/vnnn5fW69Ro6I09O5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kwZTNXXDWWWeV1puNozc7F+LJJ59sWGs2hl+nY8eOldaXLl1aWm/2Z7AXLVrUsDZv3rzSdVeuXFlab2cq6rqwZweSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJLievQvmzJlTWt+0aVNpfdWqVaX1++6772RbSuGTTz5pWJs2bVrpus8991xpfeHChS311A1czw4kR9iBJAg7kARhB5Ig7EAShB1IgrADSXA9exc88cQTba3/9ttvV9RJLhs2bGhYe/DBB0vXnTVrVtXt1K7pnt32StsHbO8csexc26/Y/ri4n9TZNgG0ayyH8ask3XzCssckbYyIiyVtLJ4D6GFNwx4Rb0g6dMLi2yWtLh6vlnRHtW0BqFqr39kviIhBSYqIQdvnN3qh7T5JfS1uB0BFOv4DXUT0S+qX8l4IA/SCVofe9tueIknF/YHqWgLQCa2Gfb2ke4vH90p6sZp2AHRK08N4289LukHSebYHJP1U0jJJv7S9UNIfJP2wk032uunTp5fWp06dWlr/8ssvS+s7duw46Z4gvfrqqw1rzcbZT0dNwx4RCxqUvldxLwA6iNNlgSQIO5AEYQeSIOxAEoQdSIJLXCtw9913l9abDc2tXbu2tL5ly5aT7gk4EXt2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCcfYKzJ8/v7Te7BLWp59+usp2gFGxZweSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJBhn74KPPvqotL558+YudYLM2LMDSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKMs4/RxIkTG9bGjx/fxU6A1jTds9teafuA7Z0jli21vdf2+8Xtls62CaBdYzmMXyXp5lGW/3tEXFncflNtWwCq1jTsEfGGpENd6AVAB7XzA90jtrcXh/mTGr3Idp/tbba3tbEtAG1qNezLJc2QdKWkQUk/b/TCiOiPiJkRMbPFbQGoQEthj4j9EfFNRByTtELStdW2BaBqLYXd9pQRT+dJ2tnotQB6Q9NxdtvPS7pB0nm2ByT9VNINtq+UFJL2SHqgcy32hjvvvLNhbcaMGaXrHjx4sOp2MAa33XZby+sePXq0wk56Q9OwR8SCURY/24FeAHQQp8sCSRB2IAnCDiRB2IEkCDuQBJe44pR1zTXXlNbnzp3b8nsvXry45XV7FXt2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCcXb0rGbj6I8++mhp/ZxzzmlYe/PNN0vX3bBhQ2n9VMSeHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSYJx9jPbs2dOwNjQ01L1GTiPjxo0rrS9atKi0ftddd5XW9+7d2/J7n45/Spo9O5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4k4Yjo3sbs7m2siz788MPSerPPeM6cOaX1Xp7y+YorriitP/zwww1rV199dem6M2fObKmn42688caGtddff72t9+5lEeHRljfds9u+yPYm27tsf2D7x8Xyc22/Yvvj4n5S1U0DqM5YDuOPSvqniLhU0ixJP7L9N5Iek7QxIi6WtLF4DqBHNQ17RAxGxLvF4yFJuyRdKOl2SauLl62WdEeHegRQgZM6N972dyVdJeltSRdExKA0/B+C7fMbrNMnqa/NPgG0acxht32mpLWSfhIRh+1RfwP4lojol9RfvMdp+QMdcCoY09Cb7fEaDvqaiFhXLN5ve0pRnyLpQGdaBFCFpnt2D+/Cn5W0KyKeGlFaL+leScuK+xc70uFp4NJLLy2tv/zyy6X1wcHBKtup1KxZs0rrkydPbvm9mw05rl+/vrS+devWlrd9OhrLYfx1kv5B0g7b7xfLFms45L+0vVDSHyT9sCMdAqhE07BHxGZJjb6gf6/adgB0CqfLAkkQdiAJwg4kQdiBJAg7kASXuFZg3rx5pfUlS5aU1q+66qoq2+kpx44da1g7dOhQ6bpPPfVUaX3ZsmUt9XS6a/kSVwCnB8IOJEHYgSQIO5AEYQeSIOxAEoQdSIJx9i6YOnVqab3Z9eyXX355le1UasWKFaX19957r2HtmWeeqbodiHF2ID3CDiRB2IEkCDuQBGEHkiDsQBKEHUiCcXbgNMM4O5AcYQeSIOxAEoQdSIKwA0kQdiAJwg4k0TTsti+yvcn2Ltsf2P5xsXyp7b223y9ut3S+XQCtanpSje0pkqZExLu2z5L0jqQ7JN0p6UhE/NuYN8ZJNUDHNTqpZizzsw9KGiweD9neJenCatsD0Gkn9Z3d9nclXSXp7WLRI7a3215pe1KDdfpsb7O9rb1WAbRjzOfG2z5T0uuSfhYR62xfIOmgpJD0hIYP9e9r8h4cxgMd1ugwfkxhtz1e0q8lbYiIb822V+zxfx0RpX8ZkbADndfyhTC2LelZSbtGBr344e64eZJ2ttskgM4Zy6/xsyX9t6Qdko7Pv7tY0gJJV2r4MH6PpAeKH/PK3os9O9BhbR3GV4WwA53H9exAcoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkmv7ByYodlPS/I56fVyzrRb3aW6/2JdFbq6rs7a8bFbp6Pfu3Nm5vi4iZtTVQold769W+JHprVbd64zAeSIKwA0nUHfb+mrdfpld769W+JHprVVd6q/U7O4DuqXvPDqBLCDuQRC1ht32z7d/Z3m37sTp6aMT2Hts7immoa52frphD74DtnSOWnWv7FdsfF/ejzrFXU289MY13yTTjtX52dU9/3vXv7LbHSfq9pO9LGpC0VdKCiPiwq400YHuPpJkRUfsJGLb/TtIRSf9xfGot2/8q6VBELCv+o5wUEf/cI70t1UlO492h3hpNM/6PqvGzq3L681bUsWe/VtLuiPg0Iv4k6ReSbq+hj54XEW9IOnTC4tslrS4er9bwP5aua9BbT4iIwYh4t3g8JOn4NOO1fnYlfXVFHWG/UNIfRzwfUG/N9x6Sfmv7Hdt9dTcziguOT7NV3J9fcz8najqNdzedMM14z3x2rUx/3q46wj7a1DS9NP53XURcLenvJf2oOFzF2CyXNEPDcwAOSvp5nc0U04yvlfSTiDhcZy8jjdJXVz63OsI+IOmiEc+/I2lfDX2MKiL2FfcHJP1Kw187esn+4zPoFvcHau7nzyJif0R8ExHHJK1QjZ9dMc34WklrImJdsbj2z260vrr1udUR9q2SLrY9zfYESfMlra+hj2+xPbH44US2J0r6gXpvKur1ku4tHt8r6cUae/kLvTKNd6NpxlXzZ1f79OcR0fWbpFs0/Iv8J5L+pY4eGvQ1XdL/FLcP6u5N0vMaPqz7Pw0fES2UNFnSRkkfF/fn9lBv/6nhqb23azhYU2rqbbaGvxpul/R+cbul7s+upK+ufG6cLgskwRl0QBKEHUiCsANJEHYgCcIOJEHYgSQIO5DE/wMI00LC2rfGngAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
+      "text/plain": "<Figure size 432x288 with 1 Axes>",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAANpklEQVR4nO3df+hVdZ7H8dcrV/+xojJWtImdioimaPshIayt1TBDW1L5jyk0tWTYjwlmaIUNVxohBmzZaemvQslyF7dhSIdkWnJa+zVmhPZj1bSZLIxRvmVipVIwa773j+9x+I597+d+vffce26+nw/4cu8973vueXPp1Tn3fM7x44gQgBPfSU03AKA/CDuQBGEHkiDsQBKEHUjir/q5Mduc+gd6LCI82vKu9uy2r7P9e9s7bT/QzWcB6C13Os5ue5ykP0j6gaTdkjZJmhcR2wvrsGcHeqwXe/YrJe2MiA8j4k+Sfinppi4+D0APdRP2syT9ccTr3dWyv2B7ge3Ntjd3sS0AXer5CbqIWCZpmcRhPNCkbvbseySdPeL1d6plAAZQN2HfJOl82+fYniBprqS19bQFoG4dH8ZHxGHb90laJ2mcpBUR8W5tnQGoVcdDbx1tjN/sQM/15KIaAN8ehB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4k0dcpm9EbM2bMaFl7/fXXi+tecMEFxfqsWbOK9RtuuKFYf+6554r1ko0bNxbrGzZs6PizM2LPDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJMIvrADj11FOL9VWrVhXr1157bcvaV199VVx3woQJxfrJJ59crPdSu96//PLLYv2ee+5pWXvmmWc66unboNUsrl1dVGN7l6SDkr6WdDgipnXzeQB6p44r6K6JiH01fA6AHuI3O5BEt2EPSb+1/abtBaO9wfYC25ttb+5yWwC60O1h/IyI2GP7ryW9YPu9iHh15BsiYpmkZRIn6IAmdbVnj4g91eNeSb+WdGUdTQGoX8dhtz3R9ilHn0v6oaRtdTUGoF4dj7PbPlfDe3Np+OfAf0XEz9usw2H8KB577LFi/a677urZtnfs2FGsf/rpp8X6gQMHOt62Pepw8J+1u1e+nYMHD7asXXXVVcV1t2zZ0tW2m1T7OHtEfCjpbzvuCEBfMfQGJEHYgSQIO5AEYQeSIOxAEtzi2gcXXXRRsf7yyy8X65MmTSrWd+/e3bJ22223FdfduXNnsf75558X64cOHSrWS046qbyvefDBB4v1xYsXF+vjxo1rWVuzZk1x3TvvvLNY/+yzz4r1JrUaemPPDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJMGVzH5xyyinFertx9HbXQjz88MMta+3G8Jt05MiRYn3JkiXFert/BnvhwoUta7Nnzy6uu2LFimK9m6mom8KeHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeS4H72Ppg5c2ax/tJLLxXrTz31VLF+xx13HG9LKXzwwQcta+ecc05x3SeffLJYnz9/fkc99QP3swPJEXYgCcIOJEHYgSQIO5AEYQeSIOxAEtzP3gcPPfRQV+u/8cYbNXWSy7p161rW7r777uK606dPr7udxrXds9teYXuv7W0jlp1h+wXb71ePp/e2TQDdGsth/FOSrjtm2QOS1kfE+ZLWV68BDLC2YY+IVyXtP2bxTZJWVs9XSrq53rYA1K3T3+yTI2Koev6xpMmt3mh7gaQFHW4HQE26PkEXEVG6wSUilklaJuW9EQYYBJ0OvX1ie4okVY9762sJQC90Gva1km6vnt8u6dl62gHQK20P420/LelqSWfa3i3pZ5KWSvqV7fmSPpI0p5dNDrpzzz23WJ86dWqx/sUXXxTrW7duPe6eIL344osta+3G2U9EbcMeEfNalL5fcy8AeojLZYEkCDuQBGEHkiDsQBKEHUiCW1xrcOuttxbr7YbmVq9eXaxv3LjxuHsCjsWeHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSYJy9BnPnzi3W293C+uijj9bZDjAq9uxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kATj7H3w3nvvFesbNmzoUyfIjD07kARhB5Ig7EAShB1IgrADSRB2IAnCDiTBOPsYTZw4sWVt/PjxfewE6EzbPbvtFbb32t42YtkS23tsv1P9Xd/bNgF0ayyH8U9Jum6U5f8eEZdWf/9db1sA6tY27BHxqqT9fegFQA91c4LuPttbqsP801u9yfYC25ttb+5iWwC61GnYH5N0nqRLJQ1J+kWrN0bEsoiYFhHTOtwWgBp0FPaI+CQivo6II5KWS7qy3rYA1K2jsNueMuLlbEnbWr0XwGBoO85u+2lJV0s60/ZuST+TdLXtSyWFpF2S7updi4Nhzpw5LWvnnXdecd19+/bV3Q7G4MYbb+x43cOHD9fYyWBoG/aImDfK4id60AuAHuJyWSAJwg4kQdiBJAg7kARhB5LgFld8a11xxRXF+qxZszr+7EWLFnW87qBizw4kQdiBJAg7kARhB5Ig7EAShB1IgrADSTDOjoHVbhz9/vvvL9ZPO+20lrXXXnutuO66deuK9W8j9uxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kATj7GO0a9eulrWDBw/2r5ETyLhx44r1hQsXFuu33HJLsb5nz56OP/tE/Kek2bMDSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKOiP5tzO7fxvpo+/btxXq773jmzJnF+iBP+XzJJZcU6/fee2/L2uWXX15cd9q0aR31dNQ111zTsvbKK6909dmDLCI82vK2e3bbZ9t+yfZ22+/a/km1/AzbL9h+v3o8ve6mAdRnLIfxhyX9U0R8T9J0ST+2/T1JD0haHxHnS1pfvQYwoNqGPSKGIuKt6vlBSTsknSXpJkkrq7etlHRzj3oEUIPjujbe9nclXSbpDUmTI2KoKn0saXKLdRZIWtBFjwBqMOaz8bZPlrRa0k8j4sDIWgyfgRr1LFRELIuIaRHR3dkWAF0ZU9htj9dw0FdFxJpq8Se2p1T1KZL29qZFAHVoexhv25KekLQjIh4ZUVor6XZJS6vHZ3vS4QngwgsvLNaff/75Yn1oaKhYb9L06dOL9UmTJnX82e2GHNeuXVusb9q0qeNtn4jG8pv97yT9SNJW2+9UyxZpOOS/sj1f0keS5vSkQwC1aBv2iNggadRBeknfr7cdAL3C5bJAEoQdSIKwA0kQdiAJwg4kwS2uNZg9e3axvnjx4mL9sssuq7OdgXLkyJGWtf379xfXfeSRR4r1pUuXdtTTia7jW1wBnBgIO5AEYQeSIOxAEoQdSIKwA0kQdiAJxtn7YOrUqcV6u/vZL7744jrbqdXy5cuL9bfffrtl7fHHH6+7HYhxdiA9wg4kQdiBJAg7kARhB5Ig7EAShB1IgnF24ATDODuQHGEHkiDsQBKEHUiCsANJEHYgCcIOJNE27LbPtv2S7e2237X9k2r5Ett7bL9T/V3f+3YBdKrtRTW2p0iaEhFv2T5F0puSbtbwfOyHIuLfxrwxLqoBeq7VRTVjmZ99SNJQ9fyg7R2Szqq3PQC9dly/2W1/V9Jlkt6oFt1ne4vtFbZPb7HOAtubbW/urlUA3RjztfG2T5b0iqSfR8Qa25Ml7ZMUkh7S8KH+HW0+g8N4oMdaHcaPKey2x0v6jaR1EfGN2faqPf5vIqL4LyMSdqD3Or4RxrYlPSFpx8igVyfujpotaVu3TQLonbGcjZ8h6XeStko6Ov/uIknzJF2q4cP4XZLuqk7mlT6LPTvQY10dxteFsAO9x/3sQHKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJNr+g5M12yfpoxGvz6yWDaJB7W1Q+5LorVN19vY3rQp9vZ/9Gxu3N0fEtMYaKBjU3ga1L4neOtWv3jiMB5Ig7EASTYd9WcPbLxnU3ga1L4neOtWX3hr9zQ6gf5reswPoE8IOJNFI2G1fZ/v3tnfafqCJHlqxvcv21moa6kbnp6vm0Ntre9uIZWfYfsH2+9XjqHPsNdTbQEzjXZhmvNHvrunpz/v+m932OEl/kPQDSbslbZI0LyK297WRFmzvkjQtIhq/AMP230s6JOk/jk6tZftfJe2PiKXV/yhPj4h/HpDelug4p/HuUW+tphn/RzX43dU5/XknmtizXylpZ0R8GBF/kvRLSTc10MfAi4hXJe0/ZvFNklZWz1dq+D+WvmvR20CIiKGIeKt6flDS0WnGG/3uCn31RRNhP0vSH0e83q3Bmu89JP3W9pu2FzTdzCgmj5hm62NJk5tsZhRtp/Hup2OmGR+Y766T6c+7xQm6b5oREZdL+gdJP64OVwdSDP8GG6Sx08cknafhOQCHJP2iyWaqacZXS/ppRBwYWWvyuxulr758b02EfY+ks0e8/k61bCBExJ7qca+kX2v4Z8cg+eToDLrV496G+/mziPgkIr6OiCOSlqvB766aZny1pFURsaZa3Ph3N1pf/fremgj7Jknn2z7H9gRJcyWtbaCPb7A9sTpxItsTJf1QgzcV9VpJt1fPb5f0bIO9/IVBmca71TTjavi7a3z684jo+5+k6zV8Rv4DSf/SRA8t+jpX0v9Wf+823ZukpzV8WPd/Gj63MV/SJEnrJb0v6X8knTFAvf2nhqf23qLhYE1pqLcZGj5E3yLpnerv+qa/u0JfffneuFwWSIITdEAShB1IgrADSRB2IAnCDiRB2IEkCDuQxP8D0wdNenALPw0AAAAASUVORK5CYII=\n"
      },
      "metadata": {
       "needs_background": "light"
@@ -152,7 +192,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 1. KernelSHAP\n",
     "\n",
@@ -163,7 +207,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The user need to specified the number of times to re-evaluate the model when explaining each prediction (`nsamples`). A binary mask need to be applied to the image to represent if an image region is hidden. It requires the background color for the masked image, which can be specified by `background`.<br>\n",
     "\n",
@@ -173,18 +221,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
+      "text/plain": "  0%|          | 0/1 [00:00<?, ?it/s]",
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a71655cb10664eb49b567a0abe1be922",
        "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
+       "version_minor": 0,
+       "model_id": "39cd0fddb1bc49d8adfc45afc73f8ee4"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -193,14 +243,18 @@
    "source": [
     "# use KernelSHAP to explain the network's predictions\n",
     "shap_values, segments_slic = dianna.explain_image(onnx_model_path, test_sample,\n",
-    "                                                  method=\"KernelSHAP\", nsamples=1000,\n",
+    "                                                  method=\"KernelSHAP\", labels=[1], nsamples=1000,\n",
     "                                                  background=0, n_segments=200, sigma=0,\n",
     "                                                  axis_labels=('height','width','channels'))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Define a function to fill each pixel with shap values based on the segmentation. <br>\n",
     "This function is used to make plots."
@@ -209,7 +263,11 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# fill each pixel with SHAP values \n",
@@ -222,7 +280,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Visualize Shapley scores on the images."
    ]
@@ -230,7 +292,11 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -241,10 +307,8 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAV0AAADtCAYAAAAcNaZ2AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Z1A+gAAAACXBIWXMAAAsTAAALEwEAmpwYAAASjElEQVR4nO3df7AddX3G8edJSOwIKMTcpIEk3qjACI4NcCfaiaU4FIwZnIAtSrQ2DLTBTpmBUadGcSoz2pY6grVToQ1DhthBApZfmZZWUoRSa4u5SWl+ECARQS7cSS4yNNB2wIRP/zjfyOH23Js995z97p7D+zVz5+z57mf3fnZJHjZ7zu46IgQAyGNa1Q0AwBsJoQsAGRG6AJARoQsAGRG6AJARoQsAGRG6JbK9zPZjtvfYXlN1PwCqZ76nWw7b0yU9LulsSSOSNktaGRGPtKqfPXt2DA4OFlr3gQPF+zjiiOK1PeXgweK106f3bw9t2LJly3MRMVB1H290/fpXsg6WSNoTEU9Iku0NklZIahm6g4ODGt68udCKx55z4SYGZvfp/1T37y9e+5a3lNPDCy8Urz3mmHJ6aIOnTXuq6h7A6YUyHS/p6ab3I2kMwBsYoVueVoejrzvstL3a9rDt4bGxsUxtAagSoVueEUkLmt7Pl/Rsc0FErI2IoYgYGhjgVBvwRkDolmezpBNsL7I9U9KFkjZW3BOAivFBWkki4oDtyyR9T9J0SesiYmfFbQGoGKFbooi4R9I9VfcBoD44vQAAGRG6AJARoQsAGXFOtwf17VVm7WjnKrORkeK18+cXr+3ba6xRJo50ASAjQhcAMiJ0ASAjQhcAMiJ0ASAjQhcAMiJ0ASAjQhcAMiJ0ASAjQhcAMuI6RkzNnj3Fa2fOLF779NOHr5H08/d9oPAqZ0xr49iine1617uK15Z1KTJ6Dke6AJARoQsAGRG6AJAR53RLZPtJSS9KOijpQEQMVdsRgKoRuuX7YEQ8V3UTAOqB0wsAkBGhW66QdK/tLbZXV90MgOpxeqFcSyPiWdtzJG2y/WhEPHhoZgri1ZK0cOHCqnoEkBFHuiWKiGfT6z5Jd0paMm7+2ogYioihgYGBKloEkBmhWxLbR9o++tC0pHMk7ai2KwBV4/RCeeZKutO21NjP34mIf6y2pS568snite1chrtrV6GyGUuXFl/ncccVr/3+94vXPvpo8dpzzy1ei75G6JYkIp6Q9CtV9wGgXji9AAAZEboAkBGhCwAZEboAkBGhCwAZEboAkBGhCwAZEboAkBGhCwAZcUUapuYznyleu3x58dqrr26/l24644zitStWFK995ZXitR/9aPFa9ByOdAEgI0IXADIidAEgI0IXADIidAEgI0IXADIidAEgI0IXADIidAEgI0K3Q7bX2d5ne0fT2Czbm2zvTq/HVtkjgPrgMuDO3STpLyV9u2lsjaT7IuJq22vS+89X0Ft5TjuteG07l/aOjBSrmz+/+DrbcUQbfyXe9rbitRs2FK/lMuC+xpFuhyLiQUnPjxteIWl9ml4v6bycPQGoL0K3HHMjYlSS0uucVkW2V9setj08NjaWtUEA1SB0KxQRayNiKCKGBgYGqm4HQAaEbjn22p4nSel1X8X9AKgJQrccGyWtStOrJN1dYS8AaoTQ7ZDtWyT9m6STbI/YvkTS1ZLOtr1b0tnpPQDwlbFORcTKCWadlbURAD2BI10AyIjQBYCMCF0AyIhzunjNxRcXr924sZweSri898WXXLj26KOi+Irb2Qdf/WrxWvQ1jnQBICNCFwAyInQBICNCFwAyInQBICNCFwAyInQBICNCFwAyInQBICOuSMNrliwpXvv8+MfC1VdbV5m148gji9fOnFlOD+g5HOkCQEaELgBkROgCQEaELgBkROh2yPY62/ts72gau8r2M7YfTj/Lq+wRQH0Qup27SdKyFuPfiIjF6eeezD0BqClCt0MR8aCk3vn+FIBKEbrlucz2tnT64diqmwFQD4RuOa6X9E5JiyWNSrqmVZHt1baHbQ+PjY1lbA9AVQjdEkTE3og4GBGvSrpBUstLvSJibUQMRcTQwMBA3iYBVILLgEtge15EjKa350vaMVl9bVx3XfHa73ynvD667YUXitcec0zx2tHRw9ccsnBh8Vr0NUK3Q7ZvkXSmpNm2RyR9WdKZthdLCklPSrq0qv4A1Auh26GIWNli+MbsjQDoCZzTBYCMCF0AyIjQBYCMCF0AyIjQBYCMCF0AyIjQBYCMCF0AyIiLI+oiQnrllWK1ZT1Z9sCB4rV33VW89j3vKVz68wMuVDfjiDae8NvOpb1LlxavHRoqXrus1S2XJ1D0z4HEU4Z7EEe6AJARoQsAGRG6AJARoQsAGRG6AJARoQsAGRG6AJARoQsAGRG6AJARodsB2wts3297l+2dti9P47Nsb7K9O70eW3WvAOqBy4A7c0DSZyNiq+2jJW2xvUnSRZLui4irba+RtEbS5yddk13KJZ179xW7rFaS5n7iE8VX/JOfTKGbw2vr8t6iVq8uXrt7d/Ha4eH2eymCS3v7Gke6HYiI0YjYmqZflLRL0vGSVkhan8rWSzqvkgYB1A6h2yW2ByWdKukhSXMjYlRqBLOkORW2BqBGCN0usH2UpNslXRER+9tYbrXtYdvDY2Nj5TUIoDYI3Q7ZnqFG4N4cEXek4b2256X58yTta7VsRKyNiKGIGBoYGMjTMIBKEbodsG1JN0raFRHXNs3aKGlVml4l6e7cvQGoJ7690Jmlkj4labvth9PYFyVdLek225dI+qmkC6ppD0DdELodiIgfSJroO1ln5ewFQG/g9AIAZEToAkBGhC4AZMQ53T43d04bl9V+6UvFa7/+9fab6aatW4vXTmvj2OLRR4vXzppVvBZIONIFgIwIXQDIiNAFgIwIXQDIiNAFgIwIXQDIiNAFgIwIXQDIiNAFgIwIXQDIyBElPH0VbRsaGorhzZuLFW/bVnzF733v1BrC4T3+ePHaE08sr4+CPG3alogYqrqPNzqOdAEgI0IXADIidAEgI0K3A7YX2L7f9i7bO21fnsavsv2M7YfTz/KqewVQD9xPtzMHJH02IrbaPlrSFtub0rxvRETFN50FUDeEbgciYlTSaJp+0fYuScdX2xWAOuP0QpfYHpR0qqSH0tBltrfZXmf72Oo6A1AnhG4X2D5K0u2SroiI/ZKul/ROSYvVOBK+ZoLlVtsetj08NjaWq10AFSJ0O2R7hhqBe3NE3CFJEbE3Ig5GxKuSbpC0pNWyEbE2IoYiYmhgYCBf0wAqQ+h2wLYl3ShpV0Rc2zQ+r6nsfEk7cvcGoJ74IK0zSyV9StJ22w+nsS9KWml7saSQ9KSkS7v6W2fO7OrqfmFkpHjt/Pnl9NBLXnqp6g7QgwjdDkTEDyS5xax7cvcCoDdwegEAMiJ0ASAjQhcAMiJ0ASAjQhcAMiJ0ASAjQhcAMiJ0ASAjQhcAMuJpwDVhe0zSU+ntbEnPVdhOmfp123phu94eEdxZqWKEbg3ZHu7XR2X367b163ah+zi9AAAZEboAkBGhW09rq26gRP26bf26XegyzukCQEYc6QJARoRuzdheZvsx23tsr6m6n6lKT0HeZ3tH09gs25ts706vPfeUZNsLbN9ve5ftnbYvT+M9v23Ig9CtEdvTJX1L0oclnazGY39OrrarKbtJ0rJxY2sk3RcRJ0i6L73vNQckfTYi3i3p/ZL+IP036odtQwaEbr0skbQnIp6IiFckbZC0ouKepiQiHpT0/LjhFZLWp+n1ks7L2VM3RMRoRGxN0y9K2iXpePXBtiEPQrdejpf0dNP7kTTWL+ZGxKjUCC9JcyrupyO2ByWdKukh9dm2oTyEbr20esglXy+pIdtHSbpd0hURsb/qftA7CN16GZG0oOn9fEnPVtRLGfbanidJ6XVfxf1Mie0ZagTuzRFxRxrui21D+Qjdetks6QTbi2zPlHShpI0V99RNGyWtStOrJN1dYS9TYtuSbpS0KyKubZrV89uGPLg4omZsL5f055KmS1oXEX9cbUdTY/sWSWeqcfetvZK+LOkuSbdJWijpp5IuiIjxH7bVmu0PSPoXSdslvZqGv6jGed2e3jbkQegCQEacXgCAjAhdAMiI0AWAjAhdAMiI0AWAjAhdAMiI0AWAjAhdAMiI0AWAjAhdAMiI0AWAjAhdAMiI0AWAjAhdAMiI0AWAjAhdAMjoiMlm2o2HIk6b9vqf8WPtvmcdrKMb67BCevXVxo/02vREY+2+Zx2sY6rriGj1kFlJHOkCQFaELgBkROgCQEaELgBkROgCQEa1fgS77dURsbbqPtpBz/n0Yt/0nEede677ke7qqhuYAnrOpxf7puc8attz3UMXAPoKoQsAGdU9dGt5TuYw6DmfXuybnvOobc+1/iANAPpN3Y90AaCvZA9d27Nsb7K9O70eO0HdMtuP2d5je03T+AW2d9p+1fZQ0/ig7f+1/XD6+ate6DvN+0Kqf8z2h2rUc8vly9jXE/XQNN+2/yLN32b7tKn23y0l9XyV7Wea9u3yGvW8zvY+2zvGLVPqfi6x71L39YQiIuuPpK9JWpOm10j6sxY10yX9WNI7JM2U9J+STk7z3i3pJEkPSBpqWmZQ0o4e7PvkVPcmSYvS8tNr0nPL5bu9ryfroalmuaR/kGRJ75f00FT7r3nPV0n6XEl/hqfcc5p3hqTTxv+3L3M/l9x3aft6sp8qTi+skLQ+Ta+XdF6LmiWS9kTEExHxiqQNaTlFxK6IeCxHo+OU1fcKSRsi4uWI+ImkPWk9lfdccPlumKyHQ1ZI+nY0/LukY2zPq7D/snouUyc9KyIelPR8i/WW/eekrL4rUUXozo2IUUlKr3Na1Bwv6emm9yNp7HAW2f4P2/9s+9c6b/V1yup7qttaRKc9T7Z8N/d1kX0wUc1U++9UWT1L0mXpn8jruvxP9U56nkyZ+7loT1P9e1TWvp7QpDcxnyrb/yTpl1vMurLoKlqMHe5rFqOSFkbEz2yfLuku26dExP6Cv7OqvqeyzGsL9+i+nkIPE9V0tP86UFbP10v6Snr/FUnXSLp4ij2O10nPVSqr7zL39YRKCd2I+I2J5tnea3teRIymw/99LcpGJC1oej9f0rOH+Z0vS3o5TW+x/WNJJ0oarnPfU1zmF0ruueXy3djXbfRwuJqZ7fbfJaX0HBF7Dw3avkHS33Wv5Y56nkyZ+7loT1PJjDL39YSqOL2wUdKqNL1K0t0tajZLOsH2ItszJV2YlpuQ7QHb09P0OySdIOmJrnVdUt9p/oW232R7kRp9/6gmPbdcvoR9XWS/bZT0O+lT6vdL+q/0T9m2+++SUno+dB4yOV/SDnVPJz1Ppsz9LJXUd8n7emK5P7mT9DZJ90nanV5npfHjJN3TVLdc0uNqfGp5ZdP4+Wr8X+1lSXslfS+N/6aknWp8srlV0kd6oe8078pU/5ikD9eo54mW7/q+btWDpE9L+nSatqRvpfnb9fpvgLTVfxf3bxk9/02q3aZGkMyrUc+3qHFq6efpz/IlOfZziX2Xuq8n+uGKNADIiCvSACAjQhcAMiJ0ASAjQhcAMiJ0ASAjQhddY/tKN+6kti3dtel9afwB//87wo2/49M30x2fpjWNXWR7LK3rEdu/14Uez7Sd5UvwQCulXJGGNx7bvyrpXEmnRcTLtmerceVVkWWnqfE95qfVuCPUA02zb42Iy2zPkbTT9sZoupII6DUc6aJb5kl6LhqXCCsinouIopczf1CNq4Gul7SyVUFE7FPji+9vbx63/ZDtU5reP2D7dNtLbP8w3ZTnh7ZPGr9ON+6n+rmm9ztsD6bp37b9o3SU/deHrsADOkXoolvulbTA9uO2r7P96+Pm35wC7GFJ94ybt1KNq4bulHSu7RnjV54uN36HGre+bLZB0sdSzTxJx0XEFkmPSjojIk6V9EeS/qTohth+t6SPS1oaEYslHZT0yaLLA5MhdNEVEfGSpNMlrZY0JulW2xc1lXwyIhanEPvFHfrTtfTLJd0VjbuUPSTpnKblPp6C+hZJl0bE+Pui3ibpgjT9MUnfTdNvlfTddO74G5JOUXFnpW3ZnH73WWoEPtAxzumiayLioBrnYx+wvV2Nm5/cdJjFlqkRkNttS9KbJf2PpL9P82+NiMsm+Z3P2P6Z7feqcXR6aZr1FUn3R8T56ZTBAy0WP6DXH3j8Unq1pPUR8YXD9A60jSNddIXtk2yf0DS0WNJTBRZdKel3I2IwIgbVeGTRObbf3Mav3yDpDyW9NSK2p7G3SnomTV80wXJPqvEYF7nxTK1Fafw+Sb+VPrw79Aywt7dcA9AmQhfdcpSk9emrXdvUePbbVZMtkIL1Q3rtqFYR8d+SfiDpI2387r9V43Z/tzWNfU3Sn9r+VzWesdXK7ZJmpVMIv6/GXawUEY9I+pKke9O2bFLjg0KgY9xlDAAy4kgXADIidAEgI0IXADIidAEgI0IXADIidAEgI0IXADIidAEgo/8DeeZJCytd3FYAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 2 Axes>"
-      ]
+      "text/plain": "<Figure size 432x288 with 2 Axes>",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAV0AAADtCAYAAAAcNaZ2AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAT40lEQVR4nO3df7BcZX3H8c8nCZGBEEjIJYYQDBHGFmdqwDspHemYCmKkLYHRQTLWhqINTpsZnVFrVFozdazUqT/aoaWNQokOhiCIpJVWIiVSBoHcYMxPMTENkhiSC6kNaCMm+faP8wSW23tvzt7d85zdm/dr5s7dfc73nP2ezfLh3LP7nHVECACQx5i6GwCA4wmhCwAZEboAkBGhCwAZEboAkBGhCwAZEboVsj3P9pO2t9teUnc/AOpnPqdbDdtjJf1I0lsl7ZK0VtKCiNgyWP2UKVNi5syZ+Rrsds28bu3q+qjb4cOlS9etX/9sRPRU2A1KGFd3A6PYHEnbI2KHJNm+Q9J8SYOG7syZM9W3dm3G9lp05Ej52jEV/EF16FD52nGj+GV+4EDpUp922lMVdoKSOL1QnemSnm64vyuNATiOEbo1sr3Idp/tvv7+/rrbAZABoVud3ZJmNNw/K429JCKWRURvRPT29HCqDTgeELrVWSvpPNvn2B4v6RpJq2ruCUDNRvE7DPWKiEO2F0v6tqSxkm6NiM01twWgZoRuhSLiPkn31d0HgM7B6QUAyIjQBYCMCF0AyIhzup3i0CFp//5ytZMnV9tLGXXPSBvNs8x+8YvytRMnVtcHKsGRLgBkROgCQEaELgBkROgCQEaELgBkROgCQEaELgBkROgCQEaELgBkROgCQEajeC5llxk3rprpvfv2la8944zytc8+W752w4bytbNmlas799zy23z88fK1c+aUr63KSSfV3QEqxJEuAGRE6AJARoQuAGTEOd0K2d4p6XlJhyUdiojeejsCUDdCt3q/ExFNvOsEYDTj9AIAZEToVisk3W97ne1FdTcDoH6cXqjWxRGx2/YZklbb/mFEPHR0YQriRZJ09tln19UjgIw40q1QROxOv/dJukfSnAHLl0VEb0T09vT01NEigMwI3YrYPtn2KUdvS7pM0qZ6uwJQN04vVGeqpHtsS8Xz/LWI+Pe2bPnAgfK1zUztbUYzU3v7+8vXPvJIubobbii/zTPPLF/76KPlaw8eLF/bzLTls84qX4uuQ+hWJCJ2SHpD3X0A6CycXgCAjAhdAMiI0AWAjAhdAMiI0AWAjAhdAMiI0AWAjAhdAMiI0AWAjJiR1o0mTqy7A2lTE5eR+Na3yteuWFGublwTL91mptU28+3J111XvnbLlvK1L75Yvnb8+PK16Agc6QJARoQuAGRE6AJARoQuAGRE6AJARoQuAGRE6AJARoQuAGRE6AJARoRui2zfanuf7U0NY5Ntr7a9Lf2eVGePADoH04Bbd5ukmyR9pWFsiaQHIuJG20vS/Y/W0Jt06FD52mam1n7kI+Vr77mnfG0V317czNTeCy8sX/vqV5evvfPO8rVXX12+Fl2HI90WRcRDkvYPGJ4vaXm6vVzSlTl7AtC5CN1qTI2IPen2M5KmDlZke5HtPtt9/f39+boDUBtCt2IREZJiiGXLIqI3Inp7enoydwagDoRuNfbaniZJ6XcTJxUBjGaEbjVWSVqYbi+UdG+NvQDoIIRui2yvkPQ9Sa+zvcv2eyXdKOmttrdJujTdBwA+MtaqiFgwxKJLsjYCoCtwpAsAGRG6AJARoQsAGXFOtxv99KflaydMKF97xRXlay+6qHztW95SvrYKVUwtlqTvfrd87TveUb62manbzdSiI3CkCwAZEboAkBGhCwAZEboAkBGhCwAZEboAkBGhCwAZEboAkBGhCwAZMSOtUxw+LB04UK72zDOr6WH27PK1Bw+Wr21mVlw3mT69fO2pp5avbeYLQpupRUfgSBcAMiJ0ASAjQhcAMiJ0ASAjQrdFtm+1vc/2poaxpbZ3216ffi6vs0cAnYPQbd1tkuYNMv6FiJidfu7L3BOADkXotigiHpK0v+4+AHQHQrc6i21vSKcfJtXdDIDOQOhW42ZJr5U0W9IeSZ8brMj2Itt9tvv6n3suY3sA6kLoViAi9kbE4Yg4IulLkuYMUbcsInojorfn9NPzNgmgFswhrIDtaRGxJ929StKm4eolSWPHShMnVtrXMX31q+Vrb7+9mh7KfulmVVOhm7FrV/na8eOr6wNdhdBtke0VkuZKmmJ7l6RPSppre7akkLRT0vV19QegsxC6LYqIBYMM35K9EQBdgXO6AJARoQsAGRG6AJARoQsAGRG6AJARoQsAGRG6AJARoQsAGTE5YrT72c/K1/7qV+VrH3mkfG1vb/nauqf3zp1bvvaMM8rXXnpp061gdOJIFwAyInQBICNCFwAyInQBICNCFwAyInQBICNCFwAyInQBICNCFwAyInRbZHuG7Qdtb7G92fYH0vhk26ttb0u/J9XdK4D6MQ24dYckfSginrB9iqR1tldLulbSAxFxo+0lkpZI+uiwWzpypNwjjmni/5WnnVa+9oYbytc++mj52rL7VZWlS8vXPvFE+doDB5pupZS6ny9UiiPdFkXEnoh4It1+XtJWSdMlzZe0PJUtl3RlLQ0C6CiEbhvZninpAkmPSZoaEXvSomckTa2rLwCdg9BtE9sTJN0t6YMR8Yq/OyMiJMUg6yyy3We7r7+/P1OnAOpE6LaB7RNUBO7tEfGNNLzX9rS0fJqkfQPXi4hlEdEbEb09PT35GgZQG0K3RbYt6RZJWyPi8w2LVklamG4vlHRv7t4AdB4+vdC6N0l6j6SNttensY9LulHSnbbfK+kpSVfX0x6ATkLotigiHpbkIRZfkrMXAJ2P0wsAkBGhCwAZEboAkJGLj5Cibr1veEP03X9/ueJmvoW2GS++WL52zZrytbNmla8999xydTt2lN9mM9N1Z88uX9tlPGbMuoho4quZUQWOdAEgI0IXADIidAEgI0IXADIidAEgI0IXADIidAEgI0IXADIidAEgI0IXADLi0o6d4oQTqpnee/Bg+dpmvoX2ssua76WdJkwoX1vVtOmq/OQn5WvPPru6PlAJjnQBICNCFwAyInQBICNCtwW2Z9h+0PYW25ttfyCNL7W92/b69HN53b0C6Ay8kdaaQ5I+FBFP2D5F0jrbq9OyL0TE39TYG4AOROi2ICL2SNqTbj9ve6uk6fV2BaCTcXqhTWzPlHSBpMfS0GLbG2zfantSfZ0B6CSEbhvYniDpbkkfjIgDkm6W9FpJs1UcCX9uiPUW2e6z3dff35+rXQA1InRbZPsEFYF7e0R8Q5IiYm9EHI6II5K+JGnOYOtGxLKI6I2I3p6ennxNA6gNodsC25Z0i6StEfH5hvFpDWVXSdqUuzcAnYk30lrzJknvkbTR9vo09nFJC2zPlhSSdkq6vo7mJEknnljbQ1dq8uTyteO67GXO1N5RrctejZ0lIh6W5EEW3Ze7FwDdgdMLAJARoQsAGRG6AJARoQsAGRG6AJARoQsAGRG6AJARoQsAGRG6AJCRI6LuHiDJdr+kp9LdKZKerbGdKo3WfeuG/XpNRHBlpZoRuh3Idl9E9NbdRxVG676N1v1C+3F6AQAyInQBICNCtzMtq7uBCo3WfRut+4U245wuAGTEkS4AZETodhjb82w/aXu77SV19zNS6VuQ99ne1DA22fZq29vS7677lmTbM2w/aHuL7c22P5DGu37fkAeh20Fsj5X095LeLul8FV/7c369XY3YbZLmDRhbIumBiDhP0gPpfrc5JOlDEXG+pIsk/Wn6NxoN+4YMCN3OMkfS9ojYEREvSrpD0vyaexqRiHhI0v4Bw/MlLU+3l0u6MmdP7RAReyLiiXT7eUlbJU3XKNg35EHodpbpkp5uuL8rjY0WUyNiT7r9jKSpdTbTKtszJV0g6TGNsn1DdQhd1CKKj8107UdnbE+QdLekD0bEgcZl3b5vqBah21l2S5rRcP+sNDZa7LU9TZLS73019zMitk9QEbi3R8Q30vCo2DdUj9DtLGslnWf7HNvjJV0jaVXNPbXTKkkL0+2Fku6tsZcRsW1Jt0jaGhGfb1jU9fuGPJgc0WFsXy7pi5LGSro1Ij5db0cjY3uFpLkqrr61V9InJX1T0p2SzlZxRbWrI2Lgm20dzfbFkv5T0kZJR9Lwx1Wc1+3qfUMehC4AZMTpBQDIiNAFgIwIXQDIiNAFgIwIXQDIiNAFgIwIXQDIiNAFgIwIXQDIiNAFgIwIXQDIiNAFgIwIXQDIiNAFgIwIXQDIiNAFgIzGDbfQLr5cb8yYV/4MHGv2PttgG+3YhhXSkSPFj/Ty7aHGmr3PNtjGSLcRYQ2BI10AyIjQBYCMCF0AyIjQBYCMCF0AyKj2r2C3vSgiltXaRAu6uf9u7l3q7v67uXepu/uvu/dOONJdVHcDLerm/ru5d6m7++/m3qXu7r/W3jshdAHguEHoAkBGnRC6XXleqEE399/NvUvd3X839y51d/+19l77G2kAcDzphCNdADhuVBa6tifbXm17W/o9aYi6halmm+2FDeOftv207RcG1F9ru9/2+vTzvi7q/VW2V9rebvsx2zPb3Xub+n+j7Y2pz7+z7TS+1Pbuhuf+8jb2PM/2k+kxlwyyfMjnzvbH0viTtt9WdpvtVFH/O9O/w3rbfZ3Wu+3TbT9o+wXbNw1YZ9DXUJf0viZt8+jr/Iy2Nh0RlfxI+qykJen2Ekl/PUjNZEk70u9J6faktOwiSdMkvTBgnWsl3VRV3xX3/ieS/jHdvkbSyg7t//G0D5b0b5LensaXSvpwBf2OlfRjSbMkjZf0A0nnl3nuJJ2f6l8l6Zy0nbFlttnJ/adlOyVNqfi13krvJ0u6WNL7B/43OdRrqEt6XyOpt6rnvMrTC/MlLU+3l0u6cpCat0laHRH7I+K/Ja2WNE+SIuLRiNhTYX/Dqar3xu3eJemSio4ARty/7WmSJqZ9CElfGWL9dpojaXtE7IiIFyXdkfah0VDP3XxJd0TELyPivyRtT9srs81O7j+XEfceET+PiIclHWwszvgaanvvOVQZulMbgucZSVMHqZku6emG+7vS2LG8w/YG23fZntFin4OpqveX1omIQ5L+R9LprbU6qFb6n55uDxw/anF67m8d6rTFCJR5Lod67obbj5G8tkaiiv4lKSTdb3ud7ao+0N9K78Ntc7jXULtU0ftR/5xOLfx5uw+Mhr2I+bHY/o6kVw+y6BONdyIibLfrYxL/ImlFRPzS9vUq/i/2lmY3UlPvbVNT/zdL+pSKMPiUpM9Juq5N28b/d3FE7E7nFFfb/mFEPFR3U8eBd6fn/RRJd0t6j4qj9bZoKXQj4tKhltnea3taROxJf27sG6Rst6S5DffPUnE+ZbjHfK7h7pdVnL9sWh29p3VmSNple5ykUyU9N/wqg6uw/93pduP47vSYexse40uS/nUkvQ/RS+NfLC895iA1A5+74dY91jbbpZL+I+Lo732271Hx53S7Q7eV3ofb5qCvoTarovfG5/15219T8by3LXSrPL2wStLRd8QXSrp3kJpvS7rM9qT0p+plaWxIKUSOukLS1jb0OlAlvQ/Y7jsl/Uc659VuI+4/nZY4YPui9GfVHx5df8Bzf5WkTW3qd62k82yfY3u8ijc8Vg2zT43P3SpJ16R3qc+RdJ6KN3HKbLNd2t6/7ZPTkZZsn6zi36ddz3e7eh/UcK+hNmt777bH2Z6Sbp8g6ffU7ue9qnfoVJw3eUDSNknfkTQ5jfdK+nJD3XUq3jzYLumPGsY/q+IczZH0e2ka/4ykzSreqXxQ0q91Ue8nSvp6qn9c0qwOfe57VbzQfizpJr08iearkjZK2qDixTytjT1fLulH6TE/kcb+UtIVx3ruVJxS+bGkJ9XwLvlg26zw9d7W/lW8I/+D9LO5yv5b7H2npP2SXkiv9fOHew11eu8qPtWwLr3GN0v6W6VPk7TrhxlpAJARM9IAICNCFwAyInQBICNCFwAyInQBICNCF21j+xO2N6dpwutt/2YaX2O7t6Fupu1NA9b9oosrmI1pGGu8otwW23/chh7n2m7XpA6gaS3NSAOOsv1bKj5IfmEUU7SnqLjyU5l1x6iYbPG0pDer+Pz1USsjYnGaCrvZ9qpomBkHdBuOdNEu0yQ9GxG/lKSIeDYiflpy3bkqPoh+s6QFgxVExD4VH4B/TeO47Udtv77h/hrbvbbn2P6e7e/bfsT26wZu08X1gT/ccH+TX77e6h/YfjwdZf+T7bEl9wUYFqGLdrlf0gzbP7L9D7bfPGD57SnA1ku6b8CyBZJWSLpH0u+m6ZevYHuWilla2wcsWinp6lQzTcUsuT5JP5T02xFxgaS/kPRXZXfE9q9LepekN0XEbEmHJb277PrAcAhdtEVEvCDpjZIWSeqXtNL2tQ0l746I2SnEXvrGiTRn/nJJ34yIA5IeU3Gt36PelYJ6haTrI2L/gIe+U8WceqkI37vS7VMlfT2dO/6CpNervEvSvqxNj32JisAHWsY5XbRNRBxWcaWyNbY3qrjQyG3HWO1tkk6TtDFdtvQkSf+rl69gtjIiFg/zmLttP2f7N1Qcnb4/LfqUpAcj4qp0ymDNIKsf0isPPE5Mvy1peUR87Bi9A03jSBdtYft1ts9rGJot6akSqy6Q9L6ImBkRM1V8Zc1bbZ/UxMOvlPRnkk6NiA1p7FS9fJm/a4dYb6ekC1P/F6bHloqLBb0zvXl39DvnXjPoFoAmEbpolwmSlqePdm1QccWmpcOtkIJ1nqRvHR2LiJ9LeljS7zfx2HepuKzfnQ1jn5X0Gdvf19B/0d0tabLtzZIWq7halSJii6QbVHxrwwYVX2U0bYhtAE3hKmMAkBFHugCQEaELABkRugCQEaELABkRugCQEaELABkRugCQEaELABn9HyLxWNxUhx0uAAAAAElFTkSuQmCC\n"
      },
      "metadata": {
       "needs_background": "light"
@@ -268,7 +332,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "\n",
     "The Shapley scores are estimated using KernelSHAP for models used to categorize the binary MNIST. The example here shows that the KernelSHAP method evaluates the importance of each segmentation/super pixel to the classification and the results are reasonable compared to the human visual preception of the chosen testing hand-written digit image."
@@ -276,7 +344,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 2. RISE\n",
     "\n",
@@ -285,7 +357,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "RISE masks random portions of the input image and passes the masked image through the model — the portion that decreases the accuracy the most is the most “important” portion.<br>\n",
     "To call the explainer and generate the relevance scores, the user need to specified the number of masks being randomly generated (`n_masks`), the resolution of features in masks (`feature_res`) and for each mask and each feature in the image, the probability of being kept unmasked (`p_keep`)."
@@ -294,13 +370,17 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Explaining: 100%|██████████| 50/50 [00:01<00:00, 38.62it/s]\n"
+      "Explaining: 100%|██████████| 50/50 [00:01<00:00, 30.92it/s]\n"
      ]
     }
    ],
@@ -313,7 +393,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Visualize the relevance scores for the predicted class on top of the image."
    ]
@@ -321,7 +405,11 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -332,10 +420,8 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Z1A+gAAAACXBIWXMAAAsTAAALEwEAmpwYAAAV8UlEQVR4nO3dW2xd5ZUH8P/y5djx3Y7jxElMgDShQBCEumgKFGVaFdFIVahGHZWHKCOhpg9FaqU+DGIeyiMaTVv1YaZSGBDpqENVVFAjCsMlQspQDR0MDbkQmtAQEieOcyNXx3Fsr3nwYeSC93+53sfnHPH9f1Jk56x8+3zeZ68c22uv7zN3h4h89tVUegIiUh5KdpFEKNlFEqFkF0mEkl0kEXXlfDKzJgc6MuM1wX899fXs2HxsbW2+OJsbmxcA1OU8y1HBZHIyOzY+nu/YEfbceY8fvabReWXxGgQTn5jg8Uh0MbN48IWzc3ru3FmMjIzMeIBcl6GZ3QfgZwBqAfy7uz/GR3QA+E5mtLmZj16yJDvW0MDHtrXlizc1Zcd6evjYKB4ZG+Px0dHs2OnTfOzVqzweJfPly3M/fnTsxkYe7+zk8e7u7FgzLvHB58/zeJTM0eQXLMgMeX2BDmXn9KmnHs+MzfnbeDOrBfCvAL4O4CYAD5jZTXM9nojMrzw/s98B4H13P+juYwB+BWBDaaYlIqWWJ9mXATgy7e+Dxcf+gpltNrMBMxsARnI8nYjkkSfZZ/olwKd+deDuW9y93937AfKDr4jMqzzJPgigb9rflwM4lm86IjJf8iT7mwBWmdl1ZlYA8G0A20ozLREptTmX3tx93MweAvASpkpvT7r73mgcq2dHddMCqUiwGBDXwkklBADQ0pIda2/nY3HuHI8HxehCUFesa8mePCvLzSaet9zMXtOo9Ba9plEdnpWoJlp5nbc2uCDGJ/n75KWgsneVVPaic84uF3ZfRa46u7u/AOCFPMcQkfLQ7bIiiVCyiyRCyS6SCCW7SCKU7CKJULKLJKLM/ey83h3V2aOuwjyifnZW6m6oCfpEoz7TqIc1qLPXkEJ/d3cXHTsStCtE/fDR1Nn4qM6edw0CdvyLF/nYq1f5xRbdOvHRRzzO7m+Izgu7HNjroXd2kUQo2UUSoWQXSYSSXSQRSnaRRCjZRRJR1tJbbS1vFW1t5ePZCq9RGSZqcc01PuoTjeo0Z87weNTLSZbGrenhNaaWxYtp/Ep9UPYL3i5om2nQyslebyBugWWtoNES19Gqu3lfcrZ4bbRiLytRq/QmIkp2kVQo2UUSoWQXSYSSXSQRSnaRRCjZRRJR9jp7R0d2PNr4ktV0o7pp3q2JaZ39wgU++ORJHh8c5PErV2j4mjVrsg996BAdu3DhQhq/Yd3dNL5idfZzA8DevQcyY9Fr8tGZD2n88Hvv8QPkUNfBl5qONnmN7ttgL2lUo2dYS7He2UUSoWQXSYSSXSQRSnaRRCjZRRKhZBdJhJJdJBFlrbO78zpgtCwx6yGOljyO4sFqzaxlHO1RUTX4whqC5ui/u/deGr/ullsyY+NBv3rtDTfQeGHlShqPFiFYtbIvOxj06V8N7k+4+uUv0/jzzz+fGXt39246tq6TN9t3dZELAvGtF2wp62i7Z7bUNDuluZLdzA4BuABgAsC4u/fnOZ6IzJ9SvLP/rbufKsFxRGQe6Wd2kUTkTXYH8LKZvWVmm2f6B2a22cwGzGxgYiLYa0hE5k3eb+PvcvdjZtYD4BUze8/dd0z/B+6+BcAWAGhoWJqzHUVE5irXO7u7Hyt+PAHgOQB3lGJSIlJ6c052M2s2s9aPPwdwL4A9pZqYiJRWnm/jFwN4zqYKe3UA/tPd/4sNmJzktfJoDfI8NfpIVBdl/cu9y8li+ACwYAENf239ehpffd11/PhEfbBg/slgO+lLwT0EY9E+21GcWM0WPwBQH7zoG+7O7sU//c47dOzwkSM03rFsGY3Xf66DxtlpidbDZzl09ix5Tn7YbO5+EMCtcx0vIuWl0ptIIpTsIolQsoskQskukgglu0giytriCsTb9DJ5loOOynpRnFaQgi+qZ9EiGr/p1qCoEewffJ48/7PPPEPHnmG9uwBGOztpfIz1WwYs6DteR1p3AeCe22+n8UZywaz74hfp2G2vvkrjl4NttpuX8PrZ4sXZ+1FH7dhsS+eDB7NjemcXSYSSXSQRSnaRRCjZRRKhZBdJhJJdJBFKdpFElL3OzurZUWsfi0erOQddpmjKLnvG8WAp6ELQZtoU1LI92LL59TfeyIwdYmsWA+FS0OHNDcE9AKz32IMW1dd+9zsar2X9nADuJEtN33jjjXTsH/fvp/H9p4I1VoPXrKUl+4IKLgd6LbM80Du7SCKU7CKJULKLJELJLpIIJbtIIpTsIolQsoskoqx19ro6XkNcsoSPZ7XuqB89qrM3N/P4woUkeJzX2esaG/nBg8LqO3v4cvz/e+JEdvCaa/hzB7324YmL6vhsje5o/e/gRX11xw4av/nOOzNjncHXfeO6dTS+P3hutLfT8BWyNHl0LbNrVXV2EVGyi6RCyS6SCCW7SCKU7CKJULKLJELJLpKIstbZCwVgxYrseHc3H9/QkB2LysFR23bBef8xjg2R2DE69Cvf+AY/dtCMP3juHB/PTlxPDx06MsnvAbjMd3RGayvfrrrQSS6xaBGCaJOBoGf8z+R16WcXIoDla9bQ+MQfd9H4Wb6sPL39IPiyaB6w5QfCd3Yze9LMTpjZnmmPdZnZK2Z2oPgxaLcXkUqbzbfxTwG47xOPPQxgu7uvArC9+HcRqWJhsrv7DgCf/KZkA4Ctxc+3Ari/tNMSkVKb6y/oFrv7EAAUP2b+YGhmm81swMwGxsZG5vh0IpLXvP823t23uHu/u/cXCsGqjiIyb+aa7MNm1gsAxY+k7UpEqsFck30bgE3FzzcB+G1ppiMi8yWss5vZ0wDWAeg2s0EAPwLwGIBfm9mDAA4D+NasnqyOt09H62Wz+mJTfbB+ebTO9+mgoDyUXWfvDPYobw3WVh8N6ujD0dzZuvRBL/1IcGhWDwb4XuEA0NKS/fzti/jcLKrDB5M7ePx4Zqw/uPHCJ/l6+UeP0jCC7dujrQYolifsUgyT3d0fyAh9NRorItVDt8uKJELJLpIIJbtIIpTsIolQsoskoqwtrmZT5bcs0e7AdIndqC9wJLhVN1oSmdSYbl27lg7tDJYVfveDD2j8yIcf0jiWLs2OBW2ik5O8vBWV1qKKJSuXnifLKQNAXx9bvxuwqAWWXTDBes1jo/zYwW7RYeltfDw7xs4ZwDuDzbJjemcXSYSSXSQRSnaRRCjZRRKhZBdJhJJdJBFKdpFElLXOPjnJW/uisinTuCBoh4zq8FFhlBRW11x7LR0atbC+8cYb/LlZ8RQAWAtt0F5bKPDzFj11dPsC25WZ3XMBxNdDXXQTwPBwduzIETq0IWgNbmvjTx3V4dl5iXayZvFcS0mLyGeDkl0kEUp2kUQo2UUSoWQXSYSSXSQRSnaRRJS9zs7axqN+dtbH29XJ66JR/3K4ti9rQA4mfiqo4R8+EeyxsWwZjzdl77QzXsfPy6VL/NBRKTtaBqBQyI41N/OxoajIz5bgJstMAwibyru6+PCTJ3mc1cqDlcnnfCnqnV0kEUp2kUQo2UUSoWQXSYSSXSQRSnaRRCjZRRJR1jr7+DgvfUZ9vKz+2NjIG697osJoSwsN15Pm6pqg9zksnLItl4Fw22VWzI5uH4jOedTPzuroAK+lR1t0110O9ouOFq1naxhE22AHX1hbA18foa2N1+nZMgPRa8Jq6bnq7Gb2pJmdMLM90x571MyOmtnO4p/10XFEpLJm8238UwDum+Hxn7r7bcU/L5R2WiJSamGyu/sOAMGaTSJS7fL8gu4hM9tV/DY/86cvM9tsZgNmNnD1anAvs4jMm7km+88BrARwG4AhAD/O+ofuvsXd+929v74+u2FDRObXnJLd3YfdfcLdJwE8DuCO0k5LREptTsluZr3T/vpNAHuy/q2IVIewzm5mTwNYB6DbzAYB/AjAOjO7DYADOATgu7N5Mne+FnjUW82WX4/W6e7pa+X/IKh1r7nllsxYV1DDH4mawqM6e9T43dGRGToTtMrnWd8ciOvsC8kW68uX87HYf5THg6bxz69cmR28wGv4k9ENBkGdvrOTr0HAzmswNVqjZ3X2MNnd/YEZHn4iGici1UW3y4okQskukgglu0gilOwiiVCyiySirC2uZrxUE3WCspWDo7KdNy6gcYvaSNlS1FGZJoqzNbIBulQ0AIwie+5RJ2e0U3U0tei0kaogak4FdcGgtLY0aEtezbbSDvaD3v7SSzQefeEdn+OlN3YtB7tsh/EsemcXSYSSXSQRSnaRRCjZRRKhZBdJhJJdJBFKdpFElLXOXlMDLCDl7rpgNqw2+dFHfOzQEI8vzbEtclQHD4vVbMljINyauKYlu8U2unch7yrXUfdtdzcJ7gvq6O3tNP6lL3yBxhtJf220Tfb7R47QOFasoOGC89e0oyN7qengFgDaAstu6dA7u0gilOwiiVCyiyRCyS6SCCW7SCKU7CKJULKLJKLs/eysLTwqR7MVmS9e5GOjvu2lN/F1jc+S4uaV6AYB9kUDcTN+0JReIHsfd3TwQjhbehjg90UAwNKlPF4zeDg7djg7BgB33nMPja+5/noaP09e9JdffJGOnQzubQgvqOPHabijt5dE+frcrA7PLjW9s4skQskukgglu0gilOwiiVCyiyRCyS6SCCW7SCLK3s/eSnZObmvj4+daXwTilvFzF/gBPiD7RV8InryBLZ4OoClY/3wkmjxZSDzqR4/WfQ+mhtWrF9P4l9qya+FL1q6lY5eR+wcAhDcJPPvMM5mxwWBN+nCt/2hf5agOT25gaOrooUPZ3gu56uxm1mdmr5nZPjPba2bfLz7eZWavmNmB4sfglRGRSprNt/HjAH7o7jcC+BsA3zOzmwA8DGC7u68CsL34dxGpUmGyu/uQu79d/PwCgH0AlgHYAGBr8Z9tBXD/PM1RRErgr/oFnZldC2AtgD8AWOzuQ8DUfwgAZvxBw8w2m9mAmQ1cuRLcbywi82bWyW5mLQB+A+AH7n5+tuPcfYu797t7f0NDsDCjiMybWSW7mdVjKtF/6e7PFh8eNrPeYrwXQLAlp4hUUlh6MzMD8ASAfe7+k2mhbQA2AXis+PG3s3lCVi2Jymds2WPW/goAZ8/yeNCRiPaVpJczKBEtCupbGzdtovGotIdVqzJDp2p5aWx0lB86qBri80t4ba7p2LHs4OAgHTsSvKh/+uADGj/K2lSj5b/Hxng82jc5apElX1uhkx+7qSm7nsouldnU2e8CsBHAbjPbWXzsEUwl+a/N7EEAhwF8axbHEpEKCZPd3V8HkHWHwVdLOx0RmS+6XVYkEUp2kUQo2UUSoWQXSYSSXSQRZW1xnZjgnYFRzZeVPqOth6PVnk+f5vEzi7IPsH3XLjr2nr4+Gu8ldXIA6I3WcyZLKnfXsD2T4/NGdj0GANgQqaMDcNKXfDloUf2f996j8f/euZPG0ZW9lXV4sUV18qgOH90bwb724EVhbcvasllElOwiqVCyiyRCyS6SCCW7SCKU7CKJULKLJKKsdXaALwfNYgCvIUYr/0bxCFvNed/Ro3Ts4Lvv0vjGjRtpvGfZMhqf7MqupZ89RIeG2LLFAHDg4EEaP06+9jd//3t+8Ght8Ztv5vHx8exYtBQ0WTocQLyAQjR3cgPDmDXQoayVnq4XwWckIp8VSnaRRCjZRRKhZBdJhJJdJBFKdpFEKNlFElHWOrs7bwNmZdG8ojp70FpNy6pXupr54DZ+8H978UUaH53kxe6hoezY8DAdGrZdL1rE4729PN5YIL3Z11xDx14araXxC8GuyED2eWsK1o1v6+HbJof98MFeAZdHsy/IaJc09bOLCKVkF0mEkl0kEUp2kUQo2UUSoWQXSYSSXSQRs9mfvQ/ALwAsATAJYIu7/8zMHgXwHQAni//0EXd/gR+L1whbW/lcWOkyWv88OnYL32YctaTky3rdAaDQyg8eLVEerWl/6lR2LGrLjkT3JzTw1mu0tGS/n0Q1/osXefz8+XzjmUKBf+E1NXwt/+h6ZKI9Dti1zJ53NjfVjAP4obu/bWatAN4ys1eKsZ+6+7/M4hgiUmGz2Z99CMBQ8fMLZrYPAF86RUSqzl/1M7uZXQtgLYA/FB96yMx2mdmTZtaZMWazmQ2Y2cDYWPD9qojMm1knu5m1APgNgB+4+3kAPwewEsBtmHrn//FM49x9i7v3u3t/ocDvRxaR+TOrZDezekwl+i/d/VkAcPdhd59w90kAjwO4Y/6mKSJ5hcluZgbgCQD73P0n0x6f3u/0TQB7Sj89ESmV2fw2/i4AGwHsNrOdxcceAfCAmd0GwAEcAvDd6EA1NbzEFZXHWKkmalGNdj0OOhJpiSkqs1y6xON5VzVm8ei585SIAKA56O5lrwsrwwJxy3O09PjZs9mx6JxHOzJH5daorMjOW3v73I/Nzslsfhv/OoCZio60pi4i1UV30IkkQskukgglu0gilOwiiVCyiyRCyS6SiLIuJV1by2uIUS2c1bqjVsxo6+EIq/lG9d75btVkqxrnraNHX1sUZzXh6N6GqIYfXS/sHoPo3oUzwTLVUdtxdD12Z++yHd5/wNqttZS0iCjZRVKhZBdJhJJdJBFKdpFEKNlFEqFkF0mEedQIXsonMzsJ4MNpD3UDIAshV1S1zq1a5wVobnNVyrmtcPcZN9oua7J/6snNBty9v2ITIKp1btU6L0Bzm6tyzU3fxoskQskukohKJ/uWCj8/U61zq9Z5AZrbXJVlbhX9mV1EyqfS7+wiUiZKdpFEVCTZzew+M/uTmb1vZg9XYg5ZzOyQme02s51mNlDhuTxpZifMbM+0x7rM7BUzO1D8OOMeexWa26NmdrR47naa2foKza3PzF4zs31mttfMvl98vKLnjsyrLOet7D+zm1ktgP0AvgZgEMCbAB5w93fLOpEMZnYIQL+7V/wGDDO7B8BFAL9w9zXFx/4ZwBl3f6z4H2Wnu/9jlcztUQAXK72Nd3G3ot7p24wDuB/AP6CC547M6+9RhvNWiXf2OwC87+4H3X0MwK8AbKjAPKqeu+8A8Mk1UzYA2Fr8fCumLpayy5hbVXD3IXd/u/j5BQAfbzNe0XNH5lUWlUj2ZQCOTPv7IKprv3cH8LKZvWVmmys9mRksdvchYOriAdBT4fl8UriNdzl9Ypvxqjl3c9n+PK9KJPtMq2RVU/3vLne/HcDXAXyv+O2qzM6stvEulxm2Ga8Kc93+PK9KJPsggL5pf18O4FgF5jEjdz9W/HgCwHOovq2ohz/eQbf48USF5/P/qmkb75m2GUcVnLtKbn9eiWR/E8AqM7vOzAoAvg1gWwXm8Slm1lz8xQnMrBnAvai+rai3AdhU/HwTgN9WcC5/oVq28c7aZhwVPncV3/7c3cv+B8B6TP1G/s8A/qkSc8iY1/UA3in+2VvpuQF4GlPf1l3F1HdEDwJYCGA7gAPFj11VNLf/ALAbwC5MJVZvheZ2N6Z+NNwFYGfxz/pKnzsyr7KcN90uK5II3UEnkgglu0gilOwiiVCyiyRCyS6SCCW7SCKU7CKJ+D/MlOC+/mB/FwAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
+      "text/plain": "<Figure size 432x288 with 1 Axes>",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAV1UlEQVR4nO3dW2xd5ZUH8P86tg/xNY5D4jgJEMoQZkJa0pGJZlKEGGhTSiuFqlJUHhAjoaYPRWqlPgxiHsojGk1b9WGmVRhQ01GHqlJBCQh1CBESA+0AhqbkRgkJudi5E5I4cRzH9poHn3QMeP+XOfvc1O//kyLbZ5299+d9zso5Pmuv7zN3h4j85SvUewAiUhtKdpFEKNlFEqFkF0mEkl0kEc21PFix2Oatrd2Z8aam8vcdFRUmJ3l8YiLf9owZj0e/d3PwKLW0kH0XghMTnbho8JE820cPSjUrSYXgdTCK53lCRtuS+JnhYYyMjs540nMlu5ndDeAnAJoA/Ie7P8bu39rajTVrvpUZ7+zkx2Pn99Ilvu3Fizx+5gyPj4zwOMOSEQC6u3l84UIeX7QoO9bVHiTM2BiPR0/q4H8iL5T/P7idH+Z3iB7UPNraeLy9nccvX+Zx9oSNHhMSf/yZZzJjZb+NN7MmAP8G4CsAVgC4z8xWlLs/EamuPH+zrwbwnrvvd/cxAL8CsK4ywxKRSsuT7EsAHJ7282Dpto8wsw1mNmBmA2NjOd4Li0guVf803t03unu/u/cXi8HfQSJSNXmSfQjANdN+Xlq6TUQaUJ5kfwPAjWZ2vZkVAXwTwJbKDEtEKq3s0pu7j5vZQwD+G1OltyfdfRfbZnwcOHUqOx5VHFhpbs4cvm1UKenq4vHR0exYVIOP6uhRlScqzdHto/JUVLOMHpSgxGSsVh6Vpy5c4PGoHs1OTEdH+dsC8fUDUZyNvUoXfeSqs7v78wCez7MPEakNXS4rkgglu0gilOwiiVCyiyRCyS6SCCW7SCJq2s8+MQEMk67FqHzISpdXXcW3bW3l8ai9lsnZBRqOPVe/e7GY7+BRnZ49oACv07OLF2Zz7Kh3mJ2Y4AG/1MLr8GdP8EPPmcPH1tVJxjY+znceXZ+QQa/sIolQsoskQskukgglu0gilOwiiVCyiySipqU3gHfv5ZhUMyzbReWvqOORle7scjDwsHwVtJlGJaZxUj4Lao4XZ551+P8P3caP3Rz1FrPfPWphjfYdlRXZgzp3Lt00Kq1FQ4+6VDs7s8+7RW3H586VdWC9soskQskukgglu0gilOwiiVCyiyRCyS6SCCW7SCJqWmcvFPgMvVGrKKulR11/UQ0/bK+dIG2HUZvn2bM8Hi0RG9Sbr/3c5zJjg0FBuKtrAY0vX34Tja9ceSONHzy4NzPW7PxBO/Tuuzx++DCNszp81F0b1cnzsklygOi6DPZ8IU9kvbKLJELJLpIIJbtIIpTsIolQsoskQskukgglu0gialpnN+MzF0cr8LIZds+fL29Ms9k3ANiC7FPVHs1THdThrwr61b+xfj2NX3/rrZmxkbZuuu3Jk3ye6okJ3jMerUx8003XZcaidvVVt36RxsfHeZ3+ueeey4wNDOym2+btV4+m/6Z3iC44iU56hlzJbmYHAAwDmAAw7u79efYnItVTiVf2f3D3UxXYj4hUkf5mF0lE3mR3AC+Y2ZtmtmGmO5jZBjMbMLOB8fHgGnARqZq8b+Nvc/chM1sIYKuZvePuL0+/g7tvBLARANrbFwcfwYlIteR6ZXf3odLXEwCeAbC6EoMSkcorO9nNrN3MOq98D2AtgJ2VGpiIVFaet/G9AJ6xqZpfM4D/cvffsg0KBV5bjersTFT3jOqmUV2U9eG39wTzlwd10S/ddReNL1+2rOz9d3TwawD27j1J40eO8BM3MsInCmC/ejQd/i23LKfxlmAHa9euy4wdPvwB3XZ8/HhwbBoOlwinPenRRR9RHT5D2cnu7vsB3FLu9iJSWyq9iSRCyS6SCCW7SCKU7CKJULKLJKLmSzazqkE0HTQrzUWlt6iaEbVb0rEFpZCFvb00vuLmm/nBA+dOn86MPU3aPAFg7/tk+V8Ax47xOZcvXgzm6CZaWnhJcnT0Dhq/887babxYzH5Q167l+968eQuNFwp8uufo+YSz5AkV1fXYctOkhqxXdpFEKNlFEqFkF0mEkl0kEUp2kUQo2UUSoWQXSUTN6+xsaeRLl8rfb9QeG5Uuo+1pKT1Y77kYHLyts5PGo87fV159NTN2YN8+uu2484Iwm/p7NvFm8gxrauK/2fbtL9F4Tw/vS77ttjWZsc9+9m/otrt3/4HGhw6/Q+MYDa4/YE+4qD+WxckJ1yu7SCKU7CKJULKLJELJLpIIJbtIIpTsIolQsoskoqZ1dndeko56ztl0z6yeCwAdHTze08Pj8+eT4JkzdNvm6OBBP/wfd/Lp+F/fsSM72NVFt23ilwiEfdnFYBZtVoe3yWASgmCSgv/9/VYa7+/PniegrW0e3fbmm3kdfujALhrPdeFHcF3GWEt79mEL6mcXSZ6SXSQRSnaRRCjZRRKhZBdJhJJdJBFKdpFE1LTO3twc17MZVo6O6sG0Tg6gr4/Hi+ez52aP6ux3fvnLfOfBetGDZF54ALyYHey7JViqOpoHwMaCSQjOkKWJ80xgAIR93wfe3ZMZW7Equ9cdAHp7l9K4NwcnJoizSwii03LqaHaMrW8QvrKb2ZNmdsLMdk67rcfMtprZ3tJXfoWCiNTdbN7G/xzA3R+77WEA29z9RgDbSj+LSAMLk93dXwbw8feR6wBsKn2/CcC9lR2WiFRauR/Q9br7lb8cjgHIXMzMzDaY2YCZDYyNkb/fRKSqcn8a7+4OMieiu29093537y8W2/IeTkTKVG6yHzezPgAofT1RuSGJSDWUm+xbADxQ+v4BAJsrMxwRqZawzm5mTwG4A8DVZjYI4AcAHgPwazN7EMBBAOtndbBmYMGC8gebZ6rtqL4/pxDM833+fGZoXnc33bRz0SIaH23P7k8GgOPBvPQXC9nbj/Hl18M6ejRPQDHq2x4j53Uk52c4wTwA+w8ezIxd+1e8zv7BB/zQQ0M8HrTi03p4WGc/Vd62YbK7+30ZobuibUWkcehyWZFEKNlFEqFkF0mEkl0kEUp2kUTUtMW1WASWks7BaMZlVoEKV7m1UX6Hk0Gt5cKFzNAtq1fTTectWULjuz/8kMZ37uXXLJ08mR1jJR4gXnI5ah3u6eF3mNNO5gePakxR/SoovbH23tHg6XD2LI+zcw7EvxqrSEZjYx3PuVpcReQvg5JdJBFKdpFEKNlFEqFkF0mEkl0kEUp2kUTUtM6Oy5eBY8cyw91RoZ31Y0YFZVInBxDXdElBeuXtt9NNR4MW2M2bfkvjR47QMG3HzFtnb8s5udDiPtK+ey7ov40KzlGcFLOj1t2oczfqzo1+teHh7BjppgagOruIBJTsIolQsoskQskukgglu0gilOwiiVCyiySitnV293xTC7OicFQYNePxqHGb9U4HdfR97/Mll3fsOETjrCYbxdnpBqp7WgCgoyP7AF3RzqOCc45id7SE97xgXeLOTh6/eJHH2dM1ujaCxdl+9coukgglu0gilOwiiVCyiyRCyS6SCCW7SCKU7CKJqG2d3Wxq8vgs4frAZNtItDZxUDBuIWMrRPVi8HpwtHnUc87iUc02qgdHdfpobKye3TUv+MWDparDOQrI3AlXneVz8S+7ju+arX8AxENn8WhqBRY/cyY7Fr6ym9mTZnbCzHZOu+1RMxsys+2lf/dE+xGR+prN2/ifA7h7htt/7O6rSv+er+ywRKTSwmR395cB8Os9RaTh5fmA7iEze7v0Nj/zSmIz22BmA2Y2MBLNGSYiVVNusv8UwA0AVgE4CuCHWXd0943u3u/u/W3hB1kiUi1lJbu7H3f3CXefBPA4AL6MqYjUXVnJbmZ90378OoCdWfcVkcYQ1tnN7CkAdwC42swGAfwAwB1mtgqAAzgA4NuzOlpTEzB3bnY8KNqOT2b/3xSV6DFO1gkHwsLoyhUrMmM97WRudAAjc3mdfcECGg4vEcgjqqNHNd9oHXIajx606DELGv3/mjWlH+JzCEwGJ6anyHvtxxfzNRBY33lUo2fYKQmT3d3vm+HmJ8ofjojUgy6XFUmEkl0kEUp2kUQo2UUSoWQXSURNW1zdChhras2MjwYzB7OSRLTac3M01XRUg2LtlKyvEABOnaLh1kt8+9a+br5/IirjRLMxRy2w0f5p9aypiW8cPGaLe3pofDmraZL2VwDY9uyzNI6zZ2l44fLlND42lv06Gz0V2Tllp1Sv7CKJULKLJELJLpIIJbtIIpTsIolQsoskQskukoja1tmd12WjUjib7bnZgzmTTwfT6AV1U7A21iNH+LZBTRcn+LTGUTF7/vzsenPUghqtihx1oUaTD9FSejB99+Lr+HzOf3/ttTQ+pzX7mo5D+/bRbd/bsYPGw77k4AKFYjH7+RSd8+jyhCx6ZRdJhJJdJBFKdpFEKNlFEqFkF0mEkl0kEUp2kUTUtM5eKPC6bFB2RbFAGnkHh/jGR4/yeNCTfoYsXXVpdbBGRtSgHDGjYXbeolWuo3kAou1JKRsA0NmZHSsEFwGsWbOGxlcuWkTj58j1Dy/87nd028noF2tr4/Fg+wvk0oo80yOwXne9soskQskukgglu0gilOwiiVCyiyRCyS6SCCW7SCJqWmfH5CRtoA5KusAHH2TH9u/n2wZL9Eb97O8fOJAZG/7qV+m2Vy1dSuNtQb14hBWrAVw4lx2L5nWPloOO4jfc0EvjX/ta9jUIn5nPa9FLosZtNpc/gKdffDEzNvjhh3zfUZ09WF58wvnrKJuvP6qznzyZHctVZzeza8zsJTPbbWa7zOy7pdt7zGyrme0tfSWLYYtIvc3mbfw4gO+7+woAfwfgO2a2AsDDALa5+40AtpV+FpEGFSa7ux9197dK3w8D2ANgCYB1ADaV7rYJwL1VGqOIVMCn+oDOzJYB+DyA1wD0uvuVC86PAZjxjzcz22BmA2Y2MBItLCYiVTPrZDezDgC/AfA9d//IR0Lu7gBmnC7S3Te6e7+797dFzQMiUjWzSnYza8FUov/S3Z8u3XzczPpK8T4AwRSpIlJPYenNzAzAEwD2uPuPpoW2AHgAwGOlr5vDo01MAOdInSiaS5rVHIJlkWnZDgjLOOjuzo4FJaIF119P4/c/9BCNHz3D1j0GSPctJibopnRbIJ7W+KabeFlx8WLybi6Y3ntkcJDG//TOOzQ+NDycHQzKmWHNMXiXGi11zf6ijab3juJZZlNn/wKA+wHsMLPtpdsewVSS/9rMHgRwEMD68oYgIrUQJru7vwIga/aEuyo7HBGpFl0uK5IIJbtIIpTsIolQsoskQskukojat7iyAiTrzwN4gTG6FPdysKRzhNRdt736Kt309hUraLy3n09FXQy6MVktPZqeOzrlQSdnOKOyk/N+MXjMfv/GGzT+P8F5p22q0VrT0RzaXV00PEIuJwH40zG63ITNLM621Su7SCKU7CKJULKLJELJLpIIJbtIIpTsIolQsoskorZ1dndeYIyagFnzdVScjKYGbm/n8QULMkN7TvB5OwaffZbGv7FwGY13dCykcdZzHtXZI9H2r7/+Jo2fPn0sM/aH14I6OZv7AIhr5ewChLzXXQTPt2geAFbGj56K88g8zmxGdL2yiyRCyS6SCCW7SCKU7CKJULKLJELJLpIIJbtIImpbZzfjBcioOMlq5fPn822D/uOwZttLliZeyOvgw8G6yT/72b/TeLTsMjtt0arHUT87650G4ssbWLy5mfeMN0ePWXRwdl3GpUt826iRP4iPkynrAf6YRb82e0zZFAF6ZRdJhJJdJBFKdpFEKNlFEqFkF0mEkl0kEUp2kUTMZn32awD8AkAvAAew0d1/YmaPAvgWgCuLpj/i7s/TnRUKvFk3KgozUV00KhhHE6CzJmK2djuAyaZgre9gDfXo8gO2lLg5L9JHQwuL/MFjNnY5+7xHa8c3BXO3h0NrJ2OL5oUP5j+4cIFvnmfd++DpRJ+Khw6RY/LdAgDGAXzf3d8ys04Ab5rZ1lLsx+7+r7PYh4jU2WzWZz8K4Gjp+2Ez2wNgSbUHJiKV9an+ZjezZQA+D+C10k0PmdnbZvakmc345sLMNpjZgJkNjETvbUSkamad7GbWAeA3AL7n7ucA/BTADQBWYeqV/4czbefuG929393726Lrz0WkamaV7GbWgqlE/6W7Pw0A7n7c3SfcfRLA4wD46oQiUldhspuZAXgCwB53/9G02/um3e3rAHZWfngiUimz+TT+CwDuB7DDzLaXbnsEwH1mtgpT5bgDAL4d7qmpCZg7Nzuep60wKp1FZb1o+87OzJDP4WWaS8FHFVGnZjSdM60qTgT1qajHdWyMx1ndD0CRlLCij3Ci2Z7j5aazn95NrfypH5XW2OrhQPy7sceso4Nvy+Ls4ZjNp/GvAJhpaLymLiINRVfQiSRCyS6SCCW7SCKU7CKJULKLJELJLpKImk4lPYkCLnh2Pbulg9e6i/NIQToqfEaiGj9pibwclKKjVs6o+zZq5WT7D5uGo51Hxewc81y3BDX66LxF2PbRvqOZpqM6enR5AjttUfctu+qcPZf0yi6SCCW7SCKU7CKJULKLJELJLpIIJbtIIpTsIokwj5qpK3kws5MADk676WoAp2o2gE+nUcfWqOMCNLZyVXJs17n7gpkCNU32TxzcbMDd++s2AKJRx9ao4wI0tnLVamx6Gy+SCCW7SCLqnewb63x8plHH1qjjAjS2ctVkbHX9m11Eaqfer+wiUiNKdpFE1CXZzexuM/uTmb1nZg/XYwxZzOyAme0ws+1mNlDnsTxpZifMbOe023rMbKuZ7S19JQv41nxsj5rZUOncbTeze+o0tmvM7CUz221mu8zsu6Xb63ruyLhqct5q/je7mTUBeBfAlwAMAngDwH3uvrumA8lgZgcA9Lt73S/AMLPbAZwH8At3X1m67V8AnHb3x0r/Uc5z939qkLE9CuB8vZfxLq1W1Dd9mXEA9wL4R9Tx3JFxrUcNzls9XtlXA3jP3fe7+xiAXwFYV4dxNDx3fxnA6Y/dvA7AptL3mzD1ZKm5jLE1BHc/6u5vlb4fBnBlmfG6njsyrpqoR7IvAXB42s+DaKz13h3AC2b2ppltqPdgZtDr7kdL3x8D0FvPwcwgXMa7lj62zHjDnLtylj/PSx/QfdJt7v63AL4C4Dult6sNyaf+Bmuk2umslvGulRmWGf+zep67cpc/z6seyT4E4JppPy8t3dYQ3H2o9PUEgGfQeEtRH7+ygm7p64k6j+fPGmkZ75mWGUcDnLt6Ln9ej2R/A8CNZna9mRUBfBPAljqM4xPMrL30wQnMrB3AWjTeUtRbADxQ+v4BAJvrOJaPaJRlvLOWGUedz13dlz9395r/A3APpj6R3wfgn+sxhoxxfQbAH0v/dtV7bACewtTbusuY+mzjQQDzAWwDsBfAiwB6Gmhs/wlgB4C3MZVYfXUa222Yeov+NoDtpX/31PvckXHV5LzpclmRROgDOpFEKNlFEqFkF0mEkl0kEUp2kUQo2UUSoWQXScT/ARqj5oNhBFiuAAAAAElFTkSuQmCC\n"
      },
      "metadata": {
       "needs_background": "light"
@@ -350,7 +436,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 3. LIME\n",
     "\n",
@@ -360,18 +450,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
+      "text/plain": "  0%|          | 0/5000 [00:00<?, ?it/s]",
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "34052a76919b4bde8d7b886d868a650d",
        "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/5000 [00:00<?, ?it/s]"
-      ]
+       "version_minor": 0,
+       "model_id": "930426ee73904594a9c005a1c425bb67"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -392,7 +484,11 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -403,10 +499,8 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Z1A+gAAAACXBIWXMAAAsTAAALEwEAmpwYAAAN70lEQVR4nO3df8yV9XnH8c9HCijWRBjCELB1LbgqU9o9EoWGsdoayz/YLF1KMkcXKmbTpU1MVtP9Uf80y1qzH8YNJilbqs7EGslC1lJiS91cx4NBRVBBZfAAg1HiwKH8kGt/PLfNU3zO9zycc58feL1fyck5577Ofe6LAx/uc+7vfc7XESEAH34X9boBAN1B2IEkCDuQBGEHkiDsQBIf6ebG7EkhXd7NTQLJvKWIEx6t0lbYbd8m6a8kjZP0DxHxQHmNyyXd2c4mARStaVhp+W287XGSHpL0RUnXSlpu+9pWnw9AZ7XzmX2BpN0R8UZEnJL0uKRl9bQFoG7thH2mpH0j7g9Vy36F7VW2B20PSifa2ByAdrQT9tEOAnzg3NuIWB0RAxExIE1qY3MA2tFO2IckzR5xf5akA+21A6BT2gn7FklzbF9te4Kkr0haX09bAOrW8tBbRJyxfY+kH2p46G1tRLxcW2cAatXWOHtEbJC0oaZeAHQQp8sCSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kERXp2xGZ1x11VUNa/v2DRXX/eupDxXr18ydW6zPaVLf9dprxXrJ1/b9UbG+d+/elp87I/bsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AE4+x9YOLEicX6C79Xngn76qvfa1g7c/p0cd1x475WrE+YMKFYb+ZjhXMAmtl15s1i/XSTP9uCf/lMw9qOHTta6ulC1lbYbe+RdFzSe5LORMRAHU0BqF8de/bfjYgjNTwPgA7iMzuQRLthD0k/sr3V9qrRHmB7le1B24PSiTY3B6BV7b6NXxQRB2xPk7TR9isRsXnkAyJitaTVkmRfGW1uD0CL2tqzR8SB6vqwpKckLaijKQD1aznsti+1fdn7tyXdKml7XY0BqFc7b+OnS3rK9vvP82hE/GstXSXzs8//e7E+d07rI5rjP1L+K/7TI39SrN/7f98s1k+dPHnePf3S8L+dhubOmVOsN/uzbV32QsPa2l+sLa5796G7ivULUcthj4g3JN1QYy8AOoihNyAJwg4kQdiBJAg7kARhB5LgK65d8LdXPFysX3td+SeTmzl27FjD2vynfqu47j1Hy8Nbv/nunxXrp06dKtbLykNvzyz5abG+ePHiYv3iwleHlyxZUl736UuK9XfffadY70fs2YEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCUd078djhn+p5s6uba9fzJo1q1jfu3J/sd7sb+imDTc2rG3Z8p9N1r5wbb7l34r1hQsXNqxddFF5P3fNo+XzD3btan0q6s5ao4gDo57AwJ4dSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Lg++xdMG5cey/zC9u2FetbtuScaGfxpkXF+i/m/W/D2uTLLy+u+/innijWf3vX/GK9H7FnB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkGGfvgp9+7mdNHnFVsXrn0Mom6w+eVz9ZvL57d8PawEB5Guy1s9c0efaHWuiot5ru2W2vtX3Y9vYRy6bY3mh7V3U9ubNtAmjXWN7Gf0/Sbecsu0/SpoiYI2lTdR9AH2sa9ojYLOnoOYuXSVpX3V4n6fZ62wJQt1YP0E2PiIOSVF1Pa/RA26tsD9oelE60uDkA7er40fiIWB0RAxExIE3q9OYANNBq2A/ZniFJ1fXh+loC0Amthn29pBXV7RWSnq6nHQCd0nSc3fZjkpZImmp7SNK3JT0g6QnbKyXtlfTlTjbZ7x6c/DfF+mWX3VGsv3vyZLF++PCh8+4J0lffbPy6bx/Y2cVO+kPTsEfE8galW2ruBUAHcboskARhB5Ig7EAShB1IgrADSfAV1xrccP31xfrkyeUvBe7YWR4G2rdvwnn3BJyLPTuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJME4ew3mzZtXrDf7CuvS/7i1yRb2nmdHwAexZweSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJBhn74IjR44U63v38n11dB57diAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgnH2MRo/fnzD2kXjxnWxE6A1TffsttfaPmx7+4hl99veb3tbdVna2TYBtGssb+O/J+m2UZY/GBHzq8uGetsCULemYY+IzZKOdqEXAB3UzgG6e2y/WL3NbziZme1VtgdtD0on2tgcgHa0GvaHJX1C0nxJByV9p9EDI2J1RAxExIA0qcXNAWhXS2GPiEMR8V5EnJW0RtKCetsCULeWwm57xoi7X5K0vdFjAfSHpuPsth+TtETSVNtDkr4taYnt+ZJC0h5Jd3Wuxf5w3XWNfxt+yuRtxXVPnOBYRS88es0/F6rXF9c9e/Zsvc30gaZhj4jloyx+pAO9AOggTpcFkiDsQBKEHUiCsANJEHYgCb7iigvW381YU6zPnfuHLT/3j3+8qeV1+xV7diAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgnF29K1m4+g333xzsX7xxRc3rO3dt6+47uuvu1i/ELFnB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkGGcfo7feeqth7eSpU91r5EPELu9rFi5cWKzPm9f4570l6djx4w1ri354U3Hds2eHivULEXt2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCcfYx2rPnzYa148eOFdedOHFisT5p0qRivZ+nfH5o+t8X6wtuvLFh7ddnzCiuO/PK8jh6Mzc82Xj9/fv3tPXcF6Kme3bbs20/Y3un7Zdtf71aPsX2Rtu7quvJnW8XQKvG8jb+jKR7I+JTkm6SdLftayXdJ2lTRMyRtKm6D6BPNQ17RByMiOer28cl7ZQ0U9IySeuqh62TdHuHegRQg/M6QGf745I+LennkqZHxEFp+D8ESdMarLPK9qDtQal/P3sCH3ZjDrvtj0p6UtI3IqJ8RGqEiFgdEQMRMSCVD0QB6Jwxhd32eA0H/fsR8YNq8SHbM6r6DEmHO9MigDo0HXqzbUmPSNoZEd8dUVovaYWkB6rrpzvS4YfAFVOnFuu7/uCNYv3422/X2U6tZs1aUaxPuuSSlp+72ZDjq6++WqwfOMDI8khjeTUWSbpD0ku2t1XLvqXhkD9he6WkvZK+3JEOAdSiadgj4llJjX4x/5Z62wHQKZwuCyRB2IEkCDuQBGEHkiDsQBIMRNZg8abPFuubfucnxfqMJl/1LFf7W0Q0rL3zzjvFdZ977rli/QvPfq7J1k83qefCnh1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkmCcvQavvLKzWL9m6JPF+u47yt9nnzZt1F/86gtbt24t1v/4v+9qWBsc3NLk2ZuNo+N8sGcHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSRc+r5x7RvzlSHd2bXtAfmsUcSBUX8Nmj07kARhB5Ig7EAShB1IgrADSRB2IAnCDiTRNOy2Z9t+xvZO2y/b/nq1/H7b+21vqy5LO98ugFaN5ccrzki6NyKet32ZpK22N1a1ByPiLzvXHoC6jGV+9oOSDla3j9veKWlmpxsDUK/z+sxu++OSPi3p59Wie2y/aHut7ckN1llle9D2oHSivW4BtGzMYbf9UUlPSvpGRByT9LCkT0iar+E9/3dGWy8iVkfEQEQMSJPa7xhAS8YUdtvjNRz070fEDyQpIg5FxHsRcVbSGkkLOtcmgHaN5Wi8JT0iaWdEfHfE8pGTi35J0vb62wNQl7EcjV8k6Q5JL9neVi37lqTltudLCkl7JDX+zWAAPTeWo/HPShrt+7Eb6m8HQKdwBh2QBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiCJLk/Z7P+R9F8jFk2VdKRrDZyffu2tX/uS6K1Vdfb2sYi4YrRCV8P+gY3bg8O/Tdd/+rW3fu1LordWdas33sYDSRB2IIleh311j7df0q+99WtfEr21qiu99fQzO4Du6fWeHUCXEHYgiZ6E3fZttl+1vdv2fb3ooRHbe2y/VE1DPdjjXtbaPmx7+4hlU2xvtL2ruh51jr0e9dYX03gXphnv6WvX6+nPu/6Z3fY4Sa9J+oKkIUlbJC2PiB1dbaQB23skDUREz0/AsL1Y0tuS/jEi5lXL/kLS0Yh4oPqPcnJEfLNPertf0tu9nsa7mq1oxshpxiXdLumr6uFrV+jr99WF160Xe/YFknZHxBsRcUrS45KW9aCPvhcRmyUdPWfxMknrqtvrNPyPpesa9NYXIuJgRDxf3T4u6f1pxnv62hX66opehH2mpH0j7g+pv+Z7D0k/sr3V9qpeNzOK6RFxUBr+xyNpWo/7OVfTaby76ZxpxvvmtWtl+vN29SLso00l1U/jf4si4jOSvijp7urtKsZmTNN4d8so04z3hVanP29XL8I+JGn2iPuzJB3oQR+jiogD1fVhSU+p/6aiPvT+DLrV9eEe9/NL/TSN92jTjKsPXrteTn/ei7BvkTTH9tW2J0j6iqT1PejjA2xfWh04ke1LJd2q/puKer2kFdXtFZKe7mEvv6JfpvFuNM24evza9Xz684jo+kXSUg0fkX9d0p/3oocGff2GpBeqy8u97k3SYxp+W3daw++IVkr6NUmbJO2qrqf0UW//JOklSS9qOFgzetTbZzX80fBFSduqy9Jev3aFvrryunG6LJAEZ9ABSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBL/D8isFh/oDrAwAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
+      "text/plain": "<Figure size 432x288 with 1 Axes>",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAN9UlEQVR4nO3df+xV9X3H8ddLCijWVBjKELB1LbghU9p9JYqGsboayz/YLDElmaMLFbPp0iYmq+n+qH+aZa3ZD+MGk5QtVWtijWQha5HYUjfX8cWgIqigIj9EGCUOHMoPee+P79F8xe/93C/3nvsD389HcnPvPe977nlz4MU595x77scRIQCffOf0ugEA3UHYgSQIO5AEYQeSIOxAEp/q5sLsCSFd2M1FAsm8rYijHqnSVtht3yTpbyWNkfTPEXFveY4LJd3WziIBFK1sWGl5N972GEn3S/qqpNmSltie3er7Aeisdj6zz5O0IyJei4jjkh6RtLietgDUrZ2wT5O0e9jzPdW0j7C93Pag7UHpaBuLA9COjh+Nj4gVETEQEQPShE4vDkAD7YR9r6QZw55Pr6YB6EPthH2jpJm2L7M9TtLXJa2ppy0AdWv51FtEnLR9p6SfaujU26qIeLG2zgDUqq3z7BGxVtLamnoB0EF8XRZIgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJLo6ZDM649JLL21Y2717T3Hev5t8f7F++axZxfrMJvXtr7xSrJd8c/efFuu7du1q+b0zYssOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0lwnr0PjB8/vlh/7o/KI2Ffdtn7DWsnT5wozjtmzDeL9XHjxhXrzXy28B2AZraffL1YP9Hkzzbv377UsLZ169aWejqbtRV22zslHZH0vqSTETFQR1MA6lfHlv0PIuJgDe8DoIP4zA4k0W7YQ9LPbG+yvXykF9hebnvQ9qB0tM3FAWhVu7vx10fEXtsXS1pn+6WI2DD8BRGxQtIKSbIviTaXB6BFbW3ZI2JvdX9A0uOS5tXRFID6tRx22+fbvuCDx5JulLSlrsYA1Kud3fgpkh63/cH7PBQR/15LV8n88g//s1ifNbP1M5pjP1X+K/6Lg39erN/1f98p1o8fO3bGPX1o6N9OQ7NmzizWm/3ZNi1+rmFt1a9XFee9Y//txfrZqOWwR8Rrkq6qsRcAHcSpNyAJwg4kQdiBJAg7kARhB5LgEtcu+IeLHijWZ19R/snkZg4fPtywNvfx3y3Oe+eh8umt337vL4v148ePF+tl5VNvTy38RbG+YMGCYv3cwqXDCxcuLM/7xHnF+nvvvVus9yO27EAShB1IgrADSRB2IAnCDiRB2IEkCDuQhCO69+MxQ79Uc1vXltcvpk+fXqzvWra3WG/2N3TN2qsb1jZu/O8mc5+9NtzwH8X6/PnzG9bOOae8nbv8ofL3D7Zvb30o6s5aqYg3R/wCA1t2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiC69m7YMyY9lbzc5s3F+sbN+YcaGfB+uuK9V/P+d+GtYkXXlic95HfebRY/73tc4v1fsSWHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeS4Dx7F/ziy79s8opLi9Xb9ixrMv/gGfWTxas7djSsDQyUh8FeNWNlk3e/v4WOeqvplt32KtsHbG8ZNm2S7XW2t1f3EzvbJoB2jWY3/oeSbjpt2t2S1kfETEnrq+cA+ljTsEfEBkmHTpu8WNLq6vFqSTfX2xaAurX6mX1KROyrHr8laUqjF9peLmn50LPPtLg4AO1q+2h8DP1iZcMrMSJiRUQMRMSANKHdxQFoUath3297qiRV9wfqawlAJ7Qa9jWSllaPl0p6op52AHRK08/sth+WtFDSZNt7JH1P0r2SHrW9TNIbkm7pZJP97r6Jf1+sX3DBrcX6e8eOFesHDuw/454gfeP1xut9y8C2LnbSH5qGPSKWNCjdUHMvADqIr8sCSRB2IAnCDiRB2IEkCDuQBJe41uCqK68s1idOLF8UuHVb+TTQ7t3jzrgn4HRs2YEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCc6z12DOnDnFerNLWBf9141NlrDrDDsCPo4tO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kwXn2Ljh48GCxvmsX16uj89iyA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EASnGcfpbFjxzasnTNmTBc7AVrTdMtue5XtA7a3DJt2j+29tjdXt0WdbRNAu0azG/9DSTeNMP2+iJhb3dbW2xaAujUNe0RskHSoC70A6KB2DtDdafv5aje/4WBmtpfbHrQ9KB1tY3EA2tFq2B+Q9HlJcyXtk/T9Ri+MiBURMRARA9KEFhcHoF0thT0i9kfE+xFxStJKSfPqbQtA3VoKu+2pw55+TdKWRq8F0B+anme3/bCkhZIm294j6XuSFtqeKykk7ZR0e+da7A9XXNH4t+EnTdxcnPfoUY5V9MJDl/+4UL2yOO+pU6fqbaYPNA17RCwZYfKDHegFQAfxdVkgCcIOJEHYgSQIO5AEYQeS4BJXnLX+cerKYn3WrD9p+b2ffHJ9y/P2K7bsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AE59nRt5qdR7/22muL9XPPPbdhbdfu3cV5X33VxfrZiC07kARhB5Ig7EAShB1IgrADSRB2IAnCDiTBefZRevvttxvWjh0/3r1GPkHs8rZm/vz5xfqcOY1/3luSDh850rB23U+vKc576tSeYv1sxJYdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5LgPPso7dz5esPakcOHi/OOHz++WJ8wYUKx3s9DPt8/5Z+K9XlXX92w9ptTpxbnnXZJ+Tx6M1c91nj+vXt3tvXeZ6OmW3bbM2w/ZXur7Rdtf6uaPsn2Otvbq/uJnW8XQKtGsxt/UtJdETFb0jWS7rA9W9LdktZHxExJ66vnAPpU07BHxL6IeLZ6fETSNknTJC2WtLp62WpJN3eoRwA1OKPP7LY/J+mLkn4laUpE7KtKb0ma0mCe5ZKWDz37TIttAmjXqI/G2/60pMckfTsiPnJEKiJCUow0X0SsiIiBiBiQygeiAHTOqMJue6yGgv6jiPhJNXm/7alVfaqkA51pEUAdmu7G27akByVti4gfDCutkbRU0r3V/RMd6fAT4KLJk4v17X/8WrF+5J136mynVtOnLy3WJ5x3Xsvv3eyU48svv1ysv/kmZ5aHG83auE7SrZJesL25mvZdDYX8UdvLJL0h6ZaOdAigFk3DHhFPS2r0i/k31NsOgE7h67JAEoQdSIKwA0kQdiAJwg4kwYnIGixYf32xvv73f16sT21yqWe52t+Gvlw5snfffbc47zPPPFOsf+XpLzdZ+okm9VzYsgNJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEpxnr8FLL20r1i/f84Vifcet5evZL7744jPuqVs2bdpUrP/ZW7c3rA0Obmzy7s3Oo+NMsGUHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSRcut649oX5kpBu69rygHxWKuLNEX8Nmi07kARhB5Ig7EAShB1IgrADSRB2IAnCDiTRNOy2Z9h+yvZW2y/a/lY1/R7be21vrm6LOt8ugFaN5scrTkq6KyKetX2BpE2211W1+yLibzrXHoC6jGZ89n2S9lWPj9jeJmlapxsDUK8z+sxu+3OSvijpV9WkO20/b3uV7YkN5llue9D2oHS0vW4BtGzUYbf9aUmPSfp2RByW9ICkz0uaq6Et//dHmi8iVkTEQEQMSBPa7xhAS0YVdttjNRT0H0XETyQpIvZHxPsRcUrSSknzOtcmgHaN5mi8JT0oaVtE/GDY9OGDi35N0pb62wNQl9Ecjb9O0q2SXrC9uZr2XUlLbM+VFJJ2Smr8m8EAem40R+OfljTS9bFr628HQKfwDTogCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EASXR6y2f8j6Y1hkyZLOti1Bs5Mv/bWr31J9NaqOnv7bERcNFKhq2H/2MLtwaHfpus//dpbv/Yl0VurutUbu/FAEoQdSKLXYV/R4+WX9Gtv/dqXRG+t6kpvPf3MDqB7er1lB9AlhB1Ioidht32T7Zdt77B9dy96aMT2TtsvVMNQD/a4l1W2D9jeMmzaJNvrbG+v7kccY69HvfXFMN6FYcZ7uu56Pfx51z+z2x4j6RVJX5G0R9JGSUsiYmtXG2nA9k5JAxHR8y9g2F4g6R1J/xIRc6ppfy3pUETcW/1HOTEivtMnvd0j6Z1eD+NdjVY0dfgw45JulvQN9XDdFfq6RV1Yb73Yss+TtCMiXouI45IekbS4B330vYjYIOnQaZMXS1pdPV6toX8sXdegt74QEfsi4tnq8RFJHwwz3tN1V+irK3oR9mmSdg97vkf9Nd57SPqZ7U22l/e6mRFMiYh91eO3JE3pZTMjaDqMdzedNsx436y7VoY/bxcH6D7u+oj4kqSvSrqj2l3tSzH0Gayfzp2OahjvbhlhmPEP9XLdtTr8ebt6Efa9kmYMez69mtYXImJvdX9A0uPqv6Go938wgm51f6DH/Xyon4bxHmmYcfXBuuvl8Oe9CPtGSTNtX2Z7nKSvS1rTgz4+xvb51YET2T5f0o3qv6Go10haWj1eKumJHvbyEf0yjHejYcbV43XX8+HPI6LrN0mLNHRE/lVJf9WLHhr09VuSnqtuL/a6N0kPa2i37oSGjm0sk/QbktZL2i7pSUmT+qi3f5X0gqTnNRSsqT3q7XoN7aI/L2lzdVvU63VX6Ksr642vywJJcIAOSIKwA0kQdiAJwg4kQdiBJAg7kARhB5L4f+eaF98iJtenAAAAAElFTkSuQmCC\n"
      },
      "metadata": {
       "needs_background": "light"
@@ -416,15 +510,8 @@
    ],
    "source": [
     "print(f'Explaination for `{pred_class}` with LIME')\n",
-    "visualization.plot_image(explanation_heatmap[0], X_test[i_instance][:,:,0], heatmap_cmap='bwr')"
+    "visualization.plot_image(explanation_heatmap[0], X_test[i_instance][:,:,0], heatmap_cmap='bwr')\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/kernelshap_geometric_shapes.ipynb
+++ b/tutorials/kernelshap_geometric_shapes.ipynb
@@ -2,7 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "<img width=\"150\" alt=\"Logo_ER10\" src=\"https://user-images.githubusercontent.com/3244249/151994514-b584b984-a148-4ade-80ee-0f88b0aefa45.png\">\n",
     "\n",
@@ -20,7 +24,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -34,7 +42,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 1 - Loading the model and the dataset\n",
     "Loads pretrained model and the image to be explained."
@@ -42,7 +54,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Load saved geometric shapes data."
    ]
@@ -50,7 +66,11 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# load dataset\n",
@@ -62,7 +82,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Load the pretrained binary MNIST model."
    ]
@@ -70,19 +94,12 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-02-11 15:27:01.628982: I tensorflow/compiler/jit/xla_cpu_device.cc:41] Not creating XLA devices, tf_xla_enable_xla_devices not set\n",
-      "2022-02-11 15:27:01.630910: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE4.1 SSE4.2 AVX AVX2 FMA\n",
-      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-02-11 15:27:01.635853: I tensorflow/core/common_runtime/process_util.cc:146] Creating new thread pool with default inter op setting: 2. Tune using inter_op_parallelism_threads for best performance.\n"
-     ]
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "# Load saved onnx model\n",
     "onnx_model_path = \"./models/geometric_shapes_model.onnx\"\n",
@@ -93,7 +110,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Print class and image of a single instance in the test data for preview."
    ]
@@ -101,31 +122,12 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:AutoGraph could not transform <bound method BackendTFModule.__call__ of <tensorflow.python.eager.function.TfMethodTarget object at 0x7f99ade28c70>> and will run it as-is.\n",
-      "Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.\n",
-      "Cause: module 'gast' has no attribute 'Index'\n",
-      "To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert\n",
-      "WARNING: AutoGraph could not transform <bound method BackendTFModule.__call__ of <tensorflow.python.eager.function.TfMethodTarget object at 0x7f99ade28c70>> and will run it as-is.\n",
-      "Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.\n",
-      "Cause: module 'gast' has no attribute 'Index'\n",
-      "To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-02-11 15:27:03.796553: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:116] None of the MLIR optimization passes are enabled (registered 2)\n",
-      "2022-02-11 15:27:03.802558: I tensorflow/core/platform/profile_utils/cpu_utils.cc:112] CPU Frequency: 2304005000 Hz\n",
-      "2022-02-11 15:27:03.845603: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:906] Skipping loop optimization for Merge node with control input: assert_equal_1/Assert/AssertGuard/branch_executed/_9\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -135,9 +137,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f99ade39550>"
-      ]
+      "text/plain": "<matplotlib.image.AxesImage at 0x24f303d3a60>"
      },
      "execution_count": 4,
      "metadata": {},
@@ -145,10 +145,8 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD7CAYAAACscuKmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAARY0lEQVR4nO3de4wd5XnH8e8PG2Mb2/EFvKywyyVyKElUTDAuEaQxEBcXUGj+cAMSjVMjVkKAuASwAXErasCUBAqqGpYkBRQaiiCABSJguaAKKSKYBhKDIQYKxmLr9QWEWyBgePrHGY/PbPZyvHvOzFm/v49kzfPOnHPm0XqfnfedmfOOIgIz2/PtVXUCZlYOF7tZIlzsZolwsZslwsVulggXu1kiRlTskhZJelXSa5KWNyspM2s+Dfc6u6QxwO+BhcBG4DngjIh4uXnpmVmzjB3Be+cDr0XEGwCS7gNOAwYsdkm+g8esxSJC/a0fSTf+QODtuvbGbJ2ZtaGRHNn7++vxR0duSV1A1wj2Y2ZNMJJi3wjMrmvPAt7p+6KI6Aa6wd14syqNpBv/HDBH0iGSxgGnAyubk5aZNduwj+wRsUPSecATwBjgpxHxUtMyM7OmGvalt2HtzN14s5Zrxdl4MxtFXOxmiXCxmyXCxW6WCBe7WSJc7GaJcLGbJcLFbpYIF7tZIlzsZolwsZslwsVulggXu1kiXOxmiXCxmyXCxW6WCBe7WSJc7GaJcLGbJcLFbpYIF7tZIlzsZolwsZslwsVulggXu1kihix2ST+V1Ctpbd266ZJWSVqfLae1Nk0zG6lGjux3AYv6rFsOrI6IOcDqrG1mbWzIYo+I/wS29Vl9GnB3Ft8N/HVz0zKzZhvumL0jInoAsuXM5qVkZq0w7Ec2N0pSF9DV6v2Y2eCGW+ybJHVGRI+kTqB3oBdGRDfQDX5ks7VeR0dHob1t264R6CeffFJ2Om1luN34lcCSLF4CPNKcdMysVRq59PZz4FfAYZI2SjoLuBFYKGk9sDBrm1kbU0R5PWt3463V3I2HiFB/61t+gs6s2WbOLF78uf322/N48eLFhW0TJ07M41SKfSC+XdYsES52s0R4zG5ta//998/j2267LY+//e1vF14n9TtEBWCvvXYdz8r8Xa/SQGN2H9nNEuFiN0uEi90sEb70ZpWaMWNGHtePywHOOOOMPB5sXF7v448/LrRTGac3wkd2s0S42M0S4W68tdz06dPz+NZbby1sO/PMM/O40a76YD766KMRf8aeykd2s0S42M0S4W68NcW0acUJhm+55ZY8/s53vpPHzeiqD+aDDz5o6eePZj6ymyXCxW6WCBe7WSI8ZreGTZ06tdD+wQ9+kMff/e53C9vqv21Wpvfff7+S/Y4GPrKbJcLFbpYId+Ptj3zuc5/L45tvvjmPly5dWnhdVV31wbgbP7D2+98ys5ZwsZslwsVulgiP2RM1ZcqUPL7pppsK284+++w8bsdx+WDqHwphRY08/mm2pKckrZP0kqQLsvXTJa2StD5bThvqs8ysOo382d4BfC8iDgeOAc6V9EVgObA6IuYAq7O2mbWpIbvxEdED9GTxdknrgAOB04AF2cvuBp4GlrUkSxuWyZMn5/GKFSsK27q6uvJ4zJgxpeXUalu3bq06hba1WwMySQcDRwLPAh3ZH4KdfxBmDvJWM6tYwyfoJE0CHgQujIj3G/1esqQuoGvIF5pZSzV0ZJe0N7VCvzcifpGt3iSpM9veCfT2996I6I6IeRExrxkJm9nwDHlkV+0Q/hNgXUT8sG7TSmAJcGO2fKQlGdqgJk2aVGjfcMMNeXzOOefk8Z40Lh/Mli1bqk6hbTXSjT8W+Fvgd5JeyNZdQa3I75d0FrABWNz/282sHTRyNv4ZYKAB+onNTcfMWsV30I0C++67b6H9/e9/P4/PPffcwrZUuusD2bx5c9UptK3RdS+kmQ2bi90sEe7Gt5H67vr111+fx+eff37hdWPH+r9tIO7GD8xHdrNEuNjNEuFiN0uEB38lmzhxYh5fd911hW0XXnhhHntcPjy+g25gPrKbJcLFbpYI9xVbYMKECXl87bXXFrZddNFFebz33nuXlVIyPHnFwHxkN0uEi90sES52s0R4zD5M48ePz+Orr766sO2SSy7JY4/Ly/Xuu+9WnULb8pHdLBEudrNEuBs/iPquOsCVV16Zx5dddlkejxs3rrScbHB+ZPPAfGQ3S4SL3SwRyXfj99lnn0L7iiuuyOPly4uPr3N3vf1t37696hTalo/sZolwsZslwsVulohkxuz1Y/Nly3Y9Wbp+jN73dTb6fPjhh1Wn0LaGPLJLGi/p15JelPSSpOuy9dMlrZK0PltOa326ZjZcjXTj/wCcEBFHAHOBRZKOAZYDqyNiDrA6a5tZm2rkWW8B/G/W3Dv7F8BpwIJs/d3A08AyKlR/aaz+Djco3v3W984423N89NFHVafQthp9PvuY7AmuvcCqiHgW6IiIHoBsObNlWZrZiDVU7BHxaUTMBWYB8yV9udEdSOqStEbSmmHmaGZNsFuX3iLiPWrd9UXAJkmdANmyd4D3dEfEvIiYN7JUzWwkhhyzS9of+CQi3pM0AfgGsAJYCSwBbsyWj7Qy0UbUz7V+9NFHF7Z5nL7n+uyzz/J4x44dFWbS3hq5zt4J3C1pDLWewP0R8aikXwH3SzoL2AAsbmGeZjZCjZyN/y1wZD/rtwIntiIpM2s+1a6slbQzqbyd9bFw4cI8fvDBB/N48uTJVaRjTfTBBx/kcf1jr1MVEepvve+NN0uEi90sEcl04+vVf9nlrrvuKmw7/fTTS87GRmrbtm15PGPGjAozaQ/uxpslzsVulggXu1kikhyzD+a4447L45UrVxa2TZvmr+y3ow0bNuTxQQcdVGEm7cFjdrPEudjNEpHMHHSNeuaZZ/K4o6OjsO1HP/pRHi9durS0nGxwfuRTY3xkN0uEi90sES52s0T40tswzZu3a+Kdxx57rLBt5kxPx1em+vMsX/va1yrMpD340ptZ4lzsZonwpbdhWrNm12S5Bx54YGHbLbfcksfnnXdeaTmlqv5bbzYwH9nNEuFiN0uEu/FN0Hf64vPPPz+P77jjjsK2xx9/PI9nzZrV2sQSsWXLlqpTGBV8ZDdLhIvdLBEudrNEeMzeYmvXri206ydXuOGGGwrbLr300jyW+r0JyvqxefPmqlMYFRo+smePbf6NpEez9nRJqyStz5aexsWsje1ON/4CYF1dezmwOiLmAKuztpm1qYa68ZJmAacA/wBcnK0+DViQxXdTe5Tzsuamt+epf+LosmXFH9edd96Zx08++WQeH3LIIa1PbBRzN74xjR7ZbwUuAz6rW9cRET0A2dJf9TJrY0MWu6RTgd6IeH44O5DUJWmNpDVDv9rMWqWRbvyxwDclnQyMB6ZI+hmwSVJnRPRI6gR6+3tzRHQD3bBnfZ/dbLRp5PnslwOXA0haAFwSEWdK+kdgCXBjtnykdWmm4bXXXsvjz3/+83l81VVXFV53zTXX5PFee/lWCY/ZGzOS35QbgYWS1gMLs7aZtanduqkmIp6mdtadiNgKnNj8lMysFTwH3ShUfxfeE088Udh22GGHlZ1O5U499dQ87jsfYIo8B51Z4lzsZonwF2FGobfeeiuPDz/88MK2iy++OI9XrFiRx2PGjGl9YhXZunVr1SmMCj6ymyXCxW6WCBe7WSJ86W0P1tnZmcf1E10CHHHEEWWn0zJf+tKX8vjll1+uMJP24EtvZolzsZslwt34RJ1zzjl5fNtttxW2jR07uq7Izp49O483btxYYSbtwd14s8S52M0S4WI3S4TH7MZ+++1XaNd/c2z+/Pllp7Pbpk3bNYv5e++9V10ibcJjdrPEudjNEuFuvA1qyZIledzd3V3YNm7cuLLT6dfEiRPz+MMPP6wwk/bgbrxZ4lzsZolwN94aNnXq1EL74YcfzuOvf/3r5SZTp3467TJ/n9uVu/FmiXOxmyXCxW6WCI/ZrSkWL15caN9zzz15PH78+Kbu6+OPPy6099lnn6Z+/mg30Ji90eezvwlsBz4FdkTEPEnTgX8HDgbeBP4mIt5tRrJm1ny7040/PiLmRsS8rL0cWB0Rc4DVWdvM2lRD3fjsyD4vIrbUrXsVWFD3yOanI2LQZw+5G5+OSZMm5fEDDzyQxyeddNKIP3v79u2F9pQpU0b8mXuSkV56C+BJSc9L6srWdURET/bhPcDMkadpZq3S6PxDx0bEO5JmAqskvdLoDrI/Dl1DvtDMWqqhI3tEvJMte4GHgPnApqz7TrbsHeC93RExr26sb2YVGHLMLmlfYK+I2J7Fq4C/p/Zs9q0RcaOk5cD0iLhsiM/ymD1xp5xySqF933335XH9OH8wmzZtKrQPOOCAkSe2BxnJpbcO4CFJO1//bxHxS0nPAfdLOgvYACwe5DPMrGJDFntEvAH80eNDImIrtaO7mY0CvoPOKjVhwoQ8vvfeewvbvvWtb/X7nvXr1xfaX/jCF5qf2Cjmb72ZJc7FbpYIF7tZIjxmt7Z1/PHH5/FDDz2Ux6+//nrhdUcddVRpOY0GHrObJc7FbpaI0fVsXkvKU089lccdHR15vHTp0irSGfV8ZDdLhIvdLBE+G2+2h/HZeLPEudjNEuFiN0uEi90sES52s0S42M0S4WI3S4SL3SwRLnazRLjYzRLhYjdLhIvdLBEudrNEuNjNEtFQsUuaKukBSa9IWifpq5KmS1olaX22nNbqZM1s+Bo9sv8T8MuI+FNqj4JaBywHVkfEHGB11jazNtXIU1ynAC8Ch0bdiyW9CiyIiJ7skc1PR8RhQ3yWJ68wa7GRTF5xKLAZ+FdJv5H04+zRzR0R0ZN9eA8ws2nZmlnTNVLsY4GvAP8SEUcC/8dudNkldUlaI2nNMHM0syZopNg3Ahsj4tms/QC14t+Udd/Jlr39vTkiuiNiXkTMa0bCZjY8QxZ7RPwP8LaknePxE4GXgZXAkmzdEuCRlmRoZk3R0OyykuYCPwbGAW8Af0ftD8X9wJ8AG4DFEbFtiM/xCTqzFhvoBJ2nkjbbw3gqabPEudjNEuFiN0uEi90sES52s0S42M0S4WI3S8TYkve3BXgL2C+Lq+Y8ipxHUTvksbs5HDTQhlJvqsl3Kq1ph3vlnYfzaPc8mpmDu/FmiXCxmyWiqmLvrmi/fTmPIudR1A55NC2HSsbsZlY+d+PNElFqsUtaJOlVSa9JKm02Wkk/ldQraW3dutKnwpY0W9JT2XTcL0m6oIpcJI2X9GtJL2Z5XFdFHnX5jMnmN3y0qjwkvSnpd5Je2DmFWkV5tGza9tKKXdIY4J+BvwK+CJwh6Ysl7f4uYFGfdVVMhb0D+F5EHA4cA5yb/QzKzuUPwAkRcQQwF1gk6ZgK8tjpAmrTk+9UVR7HR8TcuktdVeTRumnbI6KUf8BXgSfq2pcDl5e4/4OBtXXtV4HOLO4EXi0rl7ocHgEWVpkLMBH4L+DPq8gDmJX9Ap8APFrV/w3wJrBfn3Wl5gFMAf6b7Fxas/Mosxt/IPB2XXtjtq4qlU6FLelg4Ejg2SpyybrOL1CbKHRV1CYUreJncitwGfBZ3boq8gjgSUnPS+qqKI+WTtteZrH3N1VOkpcCJE0CHgQujIj3q8ghIj6NiLnUjqzzJX257BwknQr0RsTzZe+7H8dGxFeoDTPPlfQXFeQwomnbh1JmsW8EZte1ZwHvlLj/vhqaCrvZJO1NrdDvjYhfVJkLQES8BzxN7ZxG2XkcC3xT0pvAfcAJkn5WQR5ExDvZshd4CJhfQR4jmrZ9KGUW+3PAHEmHSBoHnE5tOuqqlD4VtiQBPwHWRcQPq8pF0v6SpmbxBOAbwCtl5xERl0fErIg4mNrvw39ExJll5yFpX0mTd8bAXwJry84jWj1te6tPfPQ50XAy8HvgdeDKEvf7c6AH+ITaX8+zgBnUTgytz5bTS8jjOGpDl98CL2T/Ti47F+DPgN9keawFrs7Wl/4zqctpAbtO0JX98ziU2vMMXwRe2vm7WdHvyFxgTfZ/8zAwrVl5+A46s0T4DjqzRLjYzRLhYjdLhIvdLBEudrNEuNjNEuFiN0uEi90sEf8P9rHgSEyuPqcAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
+      "text/plain": "<Figure size 432x288 with 1 Axes>",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD7CAYAAACscuKmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAARxElEQVR4nO3df6xcZZ3H8feHlv6iLf0BvTZtF6oigslStLIYcQW0CytE1gQQ1LVsG29CgICItEBEWHfFGrX8yAa4igskrAVBoIEgdLslG5INUhbQ0ootLGib0t8N3QWEynf/mNPDnOv9MdyZOWdun88raeZ7zpmZ801nvvd5nnPOPEcRgZnt/w6oOgEzK4eL3SwRLnazRLjYzRLhYjdLhIvdLBFNFbukUyW9IGmDpMWtSsrMWk9DPc8uaQTwO2AesBF4Cjg3Ita2Lj0za5WRTbz2OGBDRLwEIGkZcAbQb7FL8hU8Zm0WEeprfTPd+BnAH+qWN2brzKwDNdOyN0RSN9Dd7v2Y2cCaKfZNwKy65ZnZuoKI6AF6wN14syo1041/CjhC0mxJo4BzgOWtScvMWm3ILXtE7JV0IfAoMAL4aUQ837LMzKylhnzqbUg7czferO3acTTezIYRF7tZIlzsZolwsZslwsVulggXu1kiXOxmiXCxmyXCxW6WCBe7WSJc7GaJcLGbJcLFbpYIF7tZIlzsZolwsZslwsVulggXu1kiXOxmiXCxmyXCxW6WCBe7WSJc7GaJcLGbJcLFbpaIQYtd0k8lbZW0pm7dFEkrJK3PHie3N00za1YjLfvtwKm91i0GVkbEEcDKbNnMOtigxR4R/wns7LX6DOCOLL4D+LvWpmVmrTbUMXtXRGzO4leBrhblY2ZtMuRbNu8TETHQ3VkldQPdze7HzJoz1GLfIml6RGyWNB3Y2t8TI6IH6AHfstnar6ur2MncufPdEejbb79ddjodZajd+OXA/CyeDzzYmnTMrF0aOfX2M+C/gCMlbZS0EPgeME/SeuCz2bKZdTBFlNezdjfe2s3deIgI9bW+6QN0ZmWbNm1aYfmmm27K47POOquwbdy4cXmcSrH3x5fLmiXCxW6WCI/ZrWMdeuiheXzjjTfm8Re/+MXC86Q+h6gAHHDAu+1Zmd/1KvU3ZnfLbpYIF7tZIlzsZonwqTer1NSpU/O4flwOcO655+bxQOPyem+99VZhOZVxeiPcspslwsVulgh3463tpkyZksfXX399YdtXvvKVPG60qz6QN998s+n32F+5ZTdLhIvdLBHuxltLTJ5cnGB46dKlefzVr341j1vRVR/I66+/3tb3H87cspslwsVulggXu1kiPGa3hk2aNKmw/MMf/jCPzzvvvMK2+l+blem1116rZL/DgVt2s0S42M0S4W68/ZmDDz44j3/wgx/k8YIFCwrPq6qrPhB34/vXeZ+WmbWFi90sES52s0R4zJ6oiRMn5vH3v//9wravfe1redyJ4/KB1N8Uwooauf3TLEmrJK2V9Lyki7P1UyStkLQ+e5w82HuZWXUa+bO9F/hGRBwNHA9cIOloYDGwMiKOAFZmy2bWoQbtxkfEZmBzFu+RtA6YAZwBnJg97Q7gcWBRW7K0IZkwYUIeL1mypLCtu7s7j0eMGFFaTu22Y8eOqlPoWO9pQCbpcOBY4EmgK/tDAPAq0NXf68yseg0foJM0HrgPuCQiXqv/XXJERH93e5HUDXT3tc3MytNQyy7pQGqFfldE/CJbvUXS9Gz7dGBrX6+NiJ6ImBsRc1uRsJkNzaAtu2pN+G3Auoj4Ud2m5cB84HvZ44NtydAGNH78+MLyddddl8fnn39+Hu9P4/KBbN++veoUOlYj3fhPAn8P/EbSs9m6K6kV+T2SFgKvAGe3JUMza4lGjsY/AfQ3cdhnWpuOmbWLr6AbBg466KDC8ne/+908vuCCCwrbUumu92fbtm1Vp9Cxhte1kGY2ZC52s0S4G99B6rvr3/nOd/L4oosuKjxv5Eh/bP1xN75/btnNEuFiN0uEi90sER78lWzcuHF5fO211xa2XXLJJXnscfnQ+Aq6/rllN0uEi90sEe4rtsHYsWPz+Jprrils+/rXv57HBx54YFkpJcOTV/TPLbtZIlzsZolwsZslwmP2IRozZkweX3311YVtl112WR57XF6uXbt2VZ1Cx3LLbpYIF7tZItyNH0B9Vx3gqquuyuPLL788j0eNGlVaTjYw37K5f27ZzRLhYjdLRPLd+NGjRxeWr7zyyjxevLh4+zp31zvfnj17qk6hY7llN0uEi90sES52s0QkM2avH5svWvTunaXrx+i9n2fDzxtvvFF1Ch1r0JZd0hhJv5L0nKTnJV2brZ8t6UlJGyTdLclHr8w6WCPd+D8CJ0fEMcAc4FRJxwNLgKUR8UFgF7CwbVmaWdMauddbAP+bLR6Y/QvgZOBL2fo7gGuAm1ufYuPqT43VX+EGxavfel8ZZ/uPN998s+oUOlaj92cfkd3BdSuwAngR2B0Re7OnbARmtCVDM2uJhoo9Iv4UEXOAmcBxwIcb3YGkbkmrJa0eWopm1grv6dRbROwGVgGfACZJ2jcMmAls6uc1PRExNyLmNpOomTVn0DG7pEOBtyNit6SxwDxqB+dWAWcCy4D5wIPtTLQR9XOtf/zjHy9s8zh9//XOO+/k8d69ewd4ZtoaOc8+HbhD0ghqPYF7IuIhSWuBZZL+CXgGuK2NeZpZkxo5Gv9r4Ng+1r9EbfxuZsOAamfWStqZVN7Oepk3b14e33fffXk8YcKEKtKxFnr99dfzuP6216mKCPW13tfGmyXCxW6WiGS68fXqf+xy++23F7adc845JWdjzdq5c2ceT506tcJMOoO78WaJc7GbJcLFbpaIJMfsAznhhBPyePny5YVtkydPLjsda8Dvf//7PD7ssMMqzKQzeMxuljgXu1kikpmDrlFPPPFEHnd1dRW23XLLLXm8YMGC0nKygfmWT41xy26WCBe7WSJc7GaJ8Km3IZo7992Jdx5++OHCtmnTppWdTtLqj7N86lOfqjCTzuBTb2aJc7GbJcKn3oZo9ep3J8udMaM4i/bSpUvz+MILLywtp1TV/+rN+ueW3SwRLnazRLgb3wK9py++6KKL8vjWW28tbHvkkUfyeObMme1NLBHbt2+vOoVhwS27WSJc7GaJcLGbJcJj9jZbs2ZNYbl+coXrrruusO2b3/xmHkt9XgRlfdi2bVvVKQwLDbfs2W2bn5H0ULY8W9KTkjZIulvSqMHew8yq81668RcD6+qWlwBLI+KDwC5gYSsTM7PWaqgbL2kmcBrwz8ClqvUxTwa+lD3lDuAa4OY25Lhfqb/j6KJFiwrbfvzjH+fxY489lsezZ89uf2LDmLvxjWm0Zb8euBzY902dCuyOiH0nmDcCM/p4nZl1iEGLXdLpwNaIeHooO5DULWm1pNWDP9vM2qWRbvwngc9L+hwwBpgI3ABMkjQya91nApv6enFE9AA9sH/9nt1suGnk/uxXAFcASDoRuCwivizp58CZwDJgPvBg+9JMw4YNG/L4Ax/4QB5/61vfKjzv29/+dh4fcIAvlfCYvTHNfFMWUTtYt4HaGP621qRkZu3wni6qiYjHgcez+CXguNanZGbt4DnohqH6q/AeffTRwrYjjzyy7HQqd/rpp+dx7/kAU+Q56MwS52I3S4R/CDMMvfLKK3l81FFHFbZdeumlebxkyZI8HjFiRPsTq8iOHTuqTmFYcMtulggXu1kiXOxmifCpt/3Y9OnT87h+okuAY445pux02uYjH/lIHq9du7bCTDqDT72ZJc7FbpYId+MTdf755+fxjTfeWNg2cuTwOiM7a9asPN64cWOFmXQGd+PNEudiN0uEi90sER6zG4ccckhhuf6XY8cd1/m/Yp48eXIe7969u7pEOoTH7GaJc7GbJcLdeBvQ/Pnz87inp6ewbdSozrgJ0Lhx4/L4jTfeqDCTzuBuvFniXOxmiXA33ho2adKkwvIDDzyQx5/+9KfLTaZO/XTaZX6fO5W78WaJc7GbJcLFbpYIj9mtJc4666zC8p133pnHY8aMaem+3nrrrcLy6NGjW/r+w11/Y/ZG78/+MrAH+BOwNyLmSpoC3A0cDrwMnB0Ru1qRrJm13nvpxp8UEXMiYm62vBhYGRFHACuzZTPrUA1147OWfW5EbK9b9wJwYkRsljQdeDwiBrz3kLvx6Rg/fnwe33vvvXl8yimnNP3ee/bsKSxPnDix6ffcnzR76i2AxyQ9Lak7W9cVEZuz+FWgq8kczayNGp1/6ISI2CRpGrBC0m/rN0ZE9NdqZ38cuvvaZmblaahlj4hN2eNW4H5qt2reknXfyR639vPanoiYWzfWN7MKDDpml3QQcEBE7MniFcA/Ap8BdkTE9yQtBqZExOWDvJfH7Ik77bTTCsvLli3L4/px/kC2bNlSWH7f+97XfGL7kWZOvXUB90va9/x/i4hfSnoKuEfSQuAV4OxWJWtmrTdosUfES8Cf3T4kInZQa93NbBjwFXRWqbFjx+bxXXfdVdj2hS98oc/XrF+/vrD8oQ99qPWJDWP+1ZtZ4lzsZolwsZslwmN261gnnXRSHt9///15/OKLLxae97GPfay0nIYDj9nNEudiN0vE8Lo3ryVl1apVedzV9e7vrBYsWFBFOsOeW3azRLjYzRLho/Fm+xkfjTdLnIvdLBEudrNEuNjNEuFiN0uEi90sES52s0S42M0S4WI3S4SL3SwRLnazRLjYzRLhYjdLhIvdLBENFbukSZLulfRbSeskfULSFEkrJK3PHie3O1kzG7pGW/YbgF9GxIep3QpqHbAYWBkRRwArs2Uz61CN3MX1YOBZ4P1R92RJLwAnRsTm7JbNj0fEkYO8lyevMGuzZiavmA1sA/5V0jOSfpLdurkrIjZnz3mV2t1ezaxDNVLsI4GPAjdHxLHA/9Gry561+H222pK6Ja2WtLrZZM1s6Bop9o3Axoh4Mlu+l1rxb8m672SPW/t6cUT0RMTciJjbioTNbGgGLfaIeBX4g6R94/HPAGuB5cD8bN184MG2ZGhmLdHQ7LKS5gA/AUYBLwH/QO0PxT3AXwCvAGdHxM5B3scH6MzarL8DdJ5K2mw/46mkzRLnYjdLhIvdLBEudrNEuNjNEuFiN0uEi90sESNL3t92ahfgHJLFVeqEHMB59OY8it5rHof1t6HUi2rynUqrq75WvhNycB7Oo8w83I03S4SL3SwRVRV7T0X7rdcJOYDz6M15FLUsj0rG7GZWPnfjzRJRarFLOlXSC5I2SCptNlpJP5W0VdKaunWlT4UtaZakVZLWSnpe0sVV5CJpjKRfSXouy+PabP1sSU9mn8/dkka1M4+6fEZk8xs+VFUekl6W9BtJz+6bQq2i70jbpm0vrdgljQD+Bfhb4GjgXElHl7T724FTe62rYirsvcA3IuJo4Hjgguz/oOxc/gicHBHHAHOAUyUdDywBlkbEB4FdwMI257HPxdSmJ9+nqjxOiog5dae6qviOtG/a9ogo5R/wCeDRuuUrgCtK3P/hwJq65ReA6Vk8HXihrFzqcngQmFdlLsA44L+Bv6J28cbIvj6vNu5/ZvYFPhl4CFBFebwMHNJrXamfC3Aw8D9kx9JanUeZ3fgZwB/qljdm66pS6VTYkg4HjgWerCKXrOv8LLWJQlcALwK7I2Jv9pSyPp/rgcuBd7LlqRXlEcBjkp6W1J2tK/tzaeu07T5Ax8BTYbeDpPHAfcAlEfFaFblExJ8iYg61lvU44MPt3mdvkk4HtkbE02Xvuw8nRMRHqQ0zL5D01/UbS/pcmpq2fTBlFvsmYFbd8sxsXVUamgq71SQdSK3Q74qIX1SZC0BE7AZWUesuT5K07/cSZXw+nwQ+L+llYBm1rvwNFeRBRGzKHrcC91P7A1j259LUtO2DKbPYnwKOyI60jgLOoTYddVVKnwpbkoDbgHUR8aOqcpF0qKRJWTyW2nGDddSK/syy8oiIKyJiZkQcTu378B8R8eWy85B0kKQJ+2Lgb4A1lPy5RLunbW/3gY9eBxo+B/yO2vjwqhL3+zNgM/A2tb+eC6mNDVcC64F/B6aUkMcJ1Lpgv6Z2/7xns/+TUnMB/hJ4JstjDXB1tv79wK+ADcDPgdElfkYnAg9VkUe2v+eyf8/v+25W9B2ZA6zOPpsHgMmtysNX0JklwgfozBLhYjdLhIvdLBEudrNEuNjNEuFiN0uEi90sES52s0T8P9VX2bzmTYN7AAAAAElFTkSuQmCC\n"
      },
      "metadata": {
       "needs_background": "light"
@@ -172,7 +170,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 2 - Compute Shapley values and visualize the relevance attributions\n",
     "Approximate Shapley values using KernelSHAP and visualize the relevance attributions on the image. <br>\n",
@@ -186,49 +188,40 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-02-11 15:27:14.517038: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:906] Skipping loop optimization for Merge node with control input: assert_equal_1/Assert/AssertGuard/branch_executed/_9\n"
-     ]
-    },
-    {
      "data": {
+      "text/plain": "  0%|          | 0/1 [00:00<?, ?it/s]",
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e677fb029d744b5a94919b598b8b5981",
        "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
+       "version_minor": 0,
+       "model_id": "ab274ef37fbb40d1a50b26da84280267"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-02-11 15:27:14.943407: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:906] Skipping loop optimization for Merge node with control input: assert_equal_1/Assert/AssertGuard/branch_executed/_9\n",
-      "2022-02-11 15:27:31.825026: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:906] Skipping loop optimization for Merge node with control input: assert_equal_1/Assert/AssertGuard/branch_executed/_9\n"
-     ]
     }
    ],
    "source": [
     "# use KernelSHAP to explain the network's predictions\n",
     "shap_values, segments_slic = dianna.explain_image(onnx_model_path, test_sample,\n",
-    "                                                  method=\"KernelSHAP\", nsamples=2000,\n",
+    "                                                  method=\"KernelSHAP\", labels=[1], nsamples=2000,\n",
     "                                                  n_segments=200, sigma=0,\n",
     "                                                  axis_labels=('channels','height','width'))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Define a function to fill each pixel with shap values based on the segmentation. <br>\n",
     "This function is used to make plots."
@@ -237,7 +230,11 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# fill each pixel with SHAP values \n",
@@ -250,22 +247,28 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Visualize Shapley scores on the images."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
+   "execution_count": 7,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkMAAAD/CAYAAADyrtK8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA+JklEQVR4nO3de5Qk130f9u+vu6enp7vntfPo6dmZ3dk39sHdJYkFdgESfIkkRFGgRZmUFJGRZNniyTFPnBzbcmj6yErsWHbsRPE5VqIkto9lRxEpSqJJi6IJmiRAOQgh8LHEm0uAAJaLxz6wz5mdmZ7uvvmjuwa1tfW4t7qqq3rq+zlnz8501+N2dc/Ub373d+8VpRSIiIiIsiqXdAOIiIiIksRgiIiIiDKNwRARERFlGoMhIiIiyjQGQ0RERJRpDIaIiIgo0xgMEVHkRGSHiCyLSL4P51Iisjfu8xBFSUR+UUQeDLnvQyLyV6NuU5YxGCIiYyLyooj8hNfzSqmzSqmqUqrVz3YRDQql1O8rpd6XdDuog8EQEUVKRApJt4FokPFnqP8YDBGRERH5dwB2APgP3a6wX+92Vf2qiJwF8HURWeo+Vuju8ysi8oyI3BCRH4nIJ2zHe6eInBORvykiF0TkVRH5FdvzUyLyH0Tkuog8JiL/UET+s0fbhkXkn4nIWRE5LyK/KyIjMV8SIl8isigifyIiF0XkdRH5FyLyy/bPcffn5a+LyA8B/LD72IdE5HT3s/+8iNzvcfy/0v35uiIiXxGRnX16aVsGgyEiMqKU+jiAswB+WilVBfCH3afeAeAggPe77HYBwAcBjAH4FQC/LSJvsT0/B2AcwHYAvwrgd0Rksvvc7wBY6W7zS91/Xv4JgP0AjgPY2z3eb5i9QqLodOvm/hTASwCW0PlMfsZj878E4G4Ah0TkLgD/FsDfBjAB4D4AL7oc/y8B+LsAPgxgBsCfA/iDyF5ARjAYIqKo/KZSakUptep8Qin1JaXU86rjYQAPAni7bZMNAP+DUmpDKfVnAJYBHOjeSH4WwN9XSt1USj0N4PfcTi4iAuCvAfhvlVKXlVI3APwjAD8f6askMnMXgHkAf7v787GmlHLNbAL4re5ndxWdPwr+tVLqq0qptlLqZaXUsy77fKK73zNKqSY6n/njzA6ZYTBERFH5sdcTIvKTIvItEbksIlcBfADAtG2T17u/yC03AVTR+Uu34Di213lmAJQBfEdErnbP8x+7jxMlZRHAS47Ptxf7Z3sRwPMa++wE8M9tn/nLAASdDBRpYjBERGEozccgIsMA/hjAPwNQU0pNAPgzdH5hB7kIoAlgwfbYose2lwCsAjislJro/hvvduURJeXHAHZoFkXbf4Z+DGCP5vE/YfvMTyilRpRSj4RpbFYxGCKiMM4D2K25bRHAMLqBjYj8JACtIcXdofl/AuA3RaQsIncA+C89tm0D+L/QqUeaBQAR2S4ibjVMRP3yFwBeBfCPRaQiIiURuVdjv38F4FdE5D0ikut+lu9w2e53AXxKRA4DgIiMi8hHomt+NjAYIqIwfgvA3+um5f+y34bd2p3/Gp1C6ysA/gsAXzQ41yfRKa5+DcC/Q6c4dN1j278D4DkA3xKR6wD+E4ADBuciilQ3oP9pdAr6zwI4B+DnNPb7C3QHGwC4BuBhdLrEnNt9Hp2BA5/pfuafBPCTUbU/K0Qp18w2EVEqicg/ATCnlPIbVUZEpI2ZISJKNRG5Q0SOSsdd6Iyy+XzS7SKirYOzXBJR2o2i0zU2j858Rf8zgC8k2iIi2lLYTUZERESZxm4yIiIiyjQGQ0RERJRpkdYMiQj73ChWSimdifpSY3p6Wi0tLSXdDNqiXnzxRVy6dIk/E0RdYX8mWEBNFKOlpSU89ti3Yz2HuE/8HAkFQbutt20uZJ5Zp/3KNlm1SXvivDZxs16z3+u9++47+9Sa6Fg/EwK1+Rqt90lBtN8za1vnPn7HsD9ncq4w23sdA4Bru6Nug9e5vK6bcz9r3zB02xnVNbW/njtPnAh1HAZDRETUV143Y5Mbo7WtbiDk3Nb0JhxFYN3L+f32CbqWbl97HSvq1xnFdoB3EBc2sHRizRAREfVV0M3Lyk7YsxT2r704A6NehT2GyX4KYry9kxUQRPGavc6R5HEA7yDOHiT1gsEQERElztk947zJ6Xa7WP/8sig6bTA9hj2Ac7th+zE5j1fXVlCXl87xnV1rum2KaxudY9iDpF6OyWCIiIj6Sufm79ed43XTeyMU8t7HXjvjfN6rjsnrGG77ut2Ug87pRee1OwMCr+10j29/TjcY89rGfgzda2Kil25WJwZDRESUuKAbmVvmqJfj69bM6NT5OIORMMcGwnUF+gVAvdZF9VJA7TxGLzVKJtm8sBgMERFRKjizBX4jm9yyDkE3Tb/twgQmbufQ3catxsctsPE7pvN66XYr6tYX6QYaJjVeQe+D2/Z+WaRei9ItDIaIiCgxbgFNUDbBecPXHVEUdFzd9kbRtePVnee2nfP8zu+9giCdQCqorX5dg15t9Xtt9ud0soFRBTtBGAwREVFinIGMST2R8zhB5zFtl9fjcQ5LNy229rtuOnU/QRkfv9ca5Qg2t7aYXM9e28F5hogGnO4vgc1fLIazKIadTFGH7i87+y/1ONtjoteaFV1peb1RcwuAvEZi2QMQ3SLmXtrj9Zxf+8Ic141fTZDJMZ3Xzfm4biZNNyByFpCbvge6+3q9/70GogyGiGIW5peCCf3YRiDtltGBjVoS8107zhR5WLrXvkP/am7VAMjO7aavk/HRLWLWCW6c+3vtE5R98WMaPOkcW7eLy+98ul1VQe13nsetqNukO8yr3X6fkShk4EeOaLBYP/BB/wDTm3HMUtWYeEXZNeCm3c7U5Yz8BmcSCAV1v/kVAvttY/9ptfPqugo6nx+T2qCwWbOgmiSv4Mo0cPN7LE4MhoiIKDE6o45M9/cLOExv1jqBk1fmRTfbZT9+mGAl7sDB73X0ck6dGqF+ZYQZDBERUWLCFCrr7u/Ua7AQ94251+Mn0ZUcNtNkum/cr43BEBER9V3YwKSXbiS3DIru8aLIujizXWG6y+IewRXV6/TjlxkzbY/1fK/XhcEQERH1nTMwcQsS3B5zK+j1qtlxnst63NnFpXNDNclMeN3QrWyXTmbEr+vL7Rr4fe12Pb2OFUQn4AibxbFnA90CWLfXY69V6iV7xGCIiIgSY7+ZmdQIOQMMr+M693XeXN1uqEHZCbcbs985/G7wOq/PefPXqbVxG6Hl9Xr8juXWHq82u/ELxIKCT2cRuvP1RNl1xmCIiIhSwe8mF3QjNM1Y6JzL7/ug0VNWMOJXaO0X2Pi1VbeWSufYlqCMmE4Wy+14Qdc56LjOQnSTrkYTDIaIiKjveu1uMR2yrnv8qGpmdEd49dL9FnS8JAuU4yp4Dgoww2IwREREfedXRBt2f5PgyeuxKG6uunVBXm3wei6uAKOXTEtcw/n7fW4GQ0RElBphMjxBAYWzaNp+LlOmQZVOZiiobqbX9vk951ZQHrS9s41xMM2C9RoYcTkOogGWyxnOVGy8w2AL8wvS5Je76bIZJpc+C0tyWJzdSm6ZFedN262AWkF8rrH3Z8FwuT6PY93+WNB7eFtdkcvU476f4Fxu8yTOgmu/zJvXNs7n3K691z5+X+u0wS8os+/nFFUxNYMhopiZ3JBN+/gVxPymmZG7bJLpey8ZufRagrI1OkXMTu020Gjot6HVApQyC4bE4GM1NAQUi52v3V7vba+h2QSWl/VPUCoB5fJtx9IJMHQKtT3b6fFcUCDkDLJ0g584Ro85MRjKMOn+VCsV3weM0sXvr7WtJO5AKO5rmMZALmqmhcMmtTctzfWIrUDINGNnEhBZbXNmtZzdaAJbY3Qb1N3OL7A0+ZnXyRbp8NrO9OfGniH0a1sUGAxlVLFYRKlUQrvdxvr6OtrtNtrtNgMjIuqroBuaTpcKYN1o0xlEurXVbeh9VMf3ek6n68pr/17b6RcQ+gkamh8VBkMZVSgUUCqV0Gq10Gw2AXQyRAyGiKifgm5oul0qgyaJ16AbNPVKp0swbe8hg6EMyOVyGBoawvDwMHbv3o3JyUnMzMygXq/jwoUL+MY3voHLly8n3UwiotCy0LWoK6hmx7TQ2WS7MG0Ckg+OGAxlQKFQQKVSwbZt2/D+978fBw8exJ49e3D48GGcPn0azzzzDK5cubJZQ0RENCgGsQ4u6jbrjMTyelw3wDHJKumMQnPbt9eAqxcMhragXC6HXC6HarWKcrmMcrmM6elpTExMYGFhAbVaDTMzMxgbG0OlUkEul2MXGRElKkzm4Pab7WD8QRf1Td2k6Nm0VieMsPVQSQVCAIOhLSefz6NcLmN4eBj33nsv3vzmN6NWq+HQoUOoVCqYmZlBpVLB8PDwZhDUbDbRbDYZDBFR3/SSzXDbf5DE3XbTouOo29OvYC9KDIa2CBHZrA0aGRlBuVzGwsICDh48iPn5ebz1rW9FqVRy7QqzRpExGCKifnHrHtHNDoUdmZQkry6jKGpmeh0SrxNs6NQbhW2H37H79d4yGBpww8PDyOfz2LVrF+644w6MjY1h9+7dGB8fx759+7Bjxw6Mjo5iaGjolkBIKYV2u41Wd0IOBkJElBRnkKA3jH5riOu16AyJN5mfyHRou9eEiX4BVNA57N1vXoFXWAyGBpiIoFgsYnh4GPv378cHPvABzM7O4u6778a2bds2s0VurECIcwsRURL8/uJ3uwkPQvbHT9zdYmGuT1BRtGkgGqbb02873c+ITtuCMBgaILlcDvl8HpVKBXNzcyiVSpibm8PY2BiOHDmCxcVFTE5OolQqIZfL+Y4OszJDDIayR/evp61w44lruHUvxx3k6xolnesQlDVwu1maLnnSagH5vP72Jtu6tcU3aMnlOut36M5AXSig1bavx+b/ubQtZeZ7PXULoE27zExZbbF/HxcGQwPEmjV67969+OAHP4jZ2VkcP34c27dvR6lUQrlcRqFQQLFYDBwm3263sbGxsTnhIg2mML8cBnY+FtMFZvuwEBgXXo2XX1bILVCyYglT5gu1hhM4uqtYBAr6t+UW8rh5U//8xWLnn042RmeOIb/sjUkgZX3vtp9XgBVUR2aKwVCKWd1cpVIJ+Xweo6OjqFarqNfr2L59O2q1GhYXF7F9+3bjOYKszJD1P8Vn4DMBA/z5GNRrP6jt1mV64zIp8LW+tvbTOVc+d2tWxHlOk8Jgr5u6dkBhi7iCzttsmP146myrU2vkt71uQXiYLJJfN1yvPzMMhlKqUChgeHgYExMTuOeee1Cr1bB3717s3LkT4+PjWFxcRKlU2qwNMmVlhjY2NmJoPRGRP90gwm37oEyEV1Cj0xbdLIdXYbBud17Q8U3aEjed7IvJ3EJexdm6QRGH1mdIPp9HsVjE+Pg4Dh8+jN27d+P48eM4fPgwRKTn2aJbrdZmATURUT+Z3OTdbrKmw8WjWHIiiG7myO/8pu2Niu75wgR0XtuaFmdHMZGkHwZDKSAim7U+u3btwszMDKanp7F9+3ZMTk7izjvvxPT0NKampiIJhIBON1mj0cDGxgYLqIkolaK88XvdTP26Xrz2MwnGTDNFYbNIpnSDHL92mc6R1Ms5dTJ3HFo/4PL5PEqlEqrVKu655x4cP34c+/btw1vf+lYMDQ2hWCxuLrER1fphzWYT6+vr2NjY2JxriIgoTUy6j3SPY7Kv18077DF02tOvbrCwNUFhjtHr9mFqikwxGEqAFdRUq1VUq1WMjIxgamoKo6OjWFpaQr1ex9TUFCqVym2TJUZFKbXZVUZE1G86Bc+m2RjdWY7tdLIwzuyQbru8nuv37Mp+TLoQLV5dkCavy29kmPN8Om3maLIBIyIYHh7G0NAQTpw4gRMnTqBWq+HNb34zRkdHsW3bNlQqFZRKpdgCIaCTGVpbW8P6+jq7yYio77yCCZ2vg4Zzu91cvQqe3Xi1KUytk58wxdZRB1C6XXI6WTqTAC/o2KZdhW6BrgkGQ31idXPZF1Kt1WrYs2cPtm/fjmPHjmF0dNRzxuiotdttNJtNFlATUd/ZgxW/AMa+vV8Q4xa82G+MXl1VphkJ+746r81ruH5QZsXktYURlB0Lymh5fR02UOslG2g/Ri8YDMVsaGgI+XweCwsLOHz4MMbGxrB//35MTExgaWkJO3fuRLVa9VxENS7NZhOrq6tYW1tjVxkR9ZVpF0eYLILOjdrtphu2mNivrW4BjO5QdK829nLz1zmn6WgvnecB92DHfr4w2TLdc/thMBQza4j8wsIC3vGOd2Bubg5ve9vbUK/XN7NFSbC6yRqNRiLnJyKyxFk3oxPkxF0I7LZPFF1DcTIJPkzaptMN6nysH6+dwVCErOCmXC6jXq9jZGQEc3NzmJiYwJ49e7Bnzx5MTk6iXC4jn8/3NRPkZJ90kTVD5CvOgD3mbtpeU+d+2MMcnbgLiSM7frsNmPwBubYGLC/rf1imp/H6WgW6qyS129DeFgCqVaBUCq6XAroBSLNpdoJCwWg5kTB0uvDCYDAUoXw+j+HhYczPz+OnfuqnUK/Xceedd2LPnj0YHh7GyMjI5jZJBkIAsLGxgZWVFayurrJuiJKTogW7UvljkMpGRS+KkUFBXVeRBESNBnD1qv77cukScOaMfkBx8iSeu7BLe72xQqET3OianQXGxoB8TiMQAsyDubExoFqNNbjVKbwPg8FQD+xrhxUKBVQqFVSrVWzfvh3z8/Oo1+uo1+uYn5+PbLLEqFgF1K1Wi5mhjOl3up0oSNQ3NrfjRjZyq93WDw4ajU5AoZtNajY3d9FhuK7rbc3Wuu4mmaHuCaIIboN4vZ9hMRgKKZfLoVgsolqt4tSpU5ifn8fevXtx4MABVKtVzM/PY2RkBNu2bUusLshPo9HA8vIyM0NElLig4ek6Mx2b1uBE8fyg68fr63V+KJP92E2WgHw+j0KhgHK5jN27d2P//v04fvw4Tpw4gXw+n8oAyK7VaqHRaKDRaDAzRESpYDK/j9v2ppmeNEx6mEa9XpdeM3K6onzvGAxpEBHk83nk8/nNGaInJyextLSE8fFxHD16FDMzM5ifn490yYw4WUPrG40GM0NElCjdYeZOpkO/vfaPY0bjQRXF67ZfV+t7r6kBnEPr3dqiM/t1rxgMaRARDA0NoVQq4dixYzhx4gT27t2Lt73tbSiXyxgaGop87bC4NRoNrKys4ObNmwyGiChRUdzQTOai0ZnYL4uBEBDt6/brwjKZasAZXPntExaDIRdWsXO1WsXY2BhKpRKmpqZQLpexb98+LCwsYHp6GuVyGaVSKfVdYm6UUiygJqJEBHVX6f7FH3UWI6sBUBziup5xHZfBkAtr1uhDhw7h5MmTqNVqOHnyJLZt24bx8XFUKhUMDw8PdCDUaDRw48YNZoaIqO/CZAmCjhNVUETRMLmeuktwWF1mcQREDIa6rHXD8vk8RkZGMDQ0hJmZGezcuRPz8/M4ePAgpqenB6orzI816WKz2WRmiIj6LuwaVG77R9mWOM+TFr2uJRY1naBWp66MQ+t7YAVAtVoNR44cwcTEBA4ePIjZ2VnU63Xs2LEDlUplcxHVrRAIAZ1JF2/evIm1tTUGQ0TUd143QNOh2DpBld9CqW7fuz3XOfbW0I9AyLQoPWj7uIO2zAdDuVwOhUIBMzMzOHHiBOr1Ot797ndj165dAzFEPixrbbL19XV2kxFRapiO6tK5SereSHUXYN0K4n49QUXpOnME6QbJYUcj2mUqGLLPGF2v11GpVDA3N4fp6Wls3759MzO01bJAbqx5hrg2GSXKNBA3/OPE5JdjLid9Wf1CN5W/1W6+diYF1G6TLgYFLG6TNIa9mfaUQSkWgclJoNXS2z6Xw9KS/gzU6+vAxob+j1Eu15lQup3T+wwOlUpAuax3cCBwOmzTTI/z2rfa4jMhduc1hb2dZSoYyuVyGBoawtTUFN71rndhYWEBd911F44ePYpisbi5rIZVQL2VWWuTra2tMTNEg6Pd1g+IDD/Xksshp3mTCMukSfmtmZQGEE0Btd8cNG7ZJed+bt+71dK4tkX3jaxWgT179LbtWiy8CozpvflqtobnntNfMSOXA27e1P8RKpWGMLxtm1m05SMo6+eWLbI/trraCQD96MadTls+GMrlcpsF0eVyGdVqFbOzs1hYWMD8/Dzm5uYwMzOzWUCdFdbaZCygpoGTkeB9K9WoBNHpCvMKaHSyOW5fO7NBXsfsKTOUy5mv4q6bFgIgzQ3kckPG6x3r/gi1293Xn8u5ZtvsvAIbr//djuUVxNrf+7h+/LdsMCQiKBQKGBkZwYkTJ7Bjxw7s3bsXR48eRbVaxdzcHEZGRjAxMYGC6Yd1C7BmoGYBNRElwbTLRHfEkc7xel3GI4uCsjpB18cZ0LrxO2YvI8V0bMkowFo+w5o1evv27Thw4ACOHTuG++67D8ViEfl8fkvXBAXh0HoiShPdgMRvWHiY+YmiKNDOgl4XRXXr1nSKvGbLwJYJhqyRX4uLi1hYWMDk5CT27duH0dFR3HHHHajVaqjX65tLZ2Q5EALeKKBmMERESfAKZLyyNiaBj27mhxkffabXyZn186vnSkMwuiWCISsTVCgUsG/fPpw8eRK7d+/Ge9/7XoyOjmJ4eHgzE5T1IMjSarWwtrbG0WRElCo6xdVhb6A62Y1eJ4OkYGFGlcVtIIMhK6CpVCqYmJjA8PAwZmZmMDIygkOHDm2uLG+tHZb1LjE37XYb7Xaba5MRUWroBh9eQYz9uXhWXye/0XduI/tMujOdx/bbNmoDGQxZXWJLS0u45557UKvV8Pa3vx31eh2jo6OoVCooFouoVCqZGiFmwpp0sdFoMBgiolQwufF5DcN2O1aYQu1+zn48SPyGvrtdJ5Nr5zcCkAXUXdZM0dakidbaYQsLC6jX69i3bx/m5+c3l9cgf1ZWqN1uMxgiosQEzfPjxa+uyK+ryy/7YP8+qQxFGnm9R4B/MXqYUXvWMfvdRZn6YCiXyyGXy2FqampzhugjR45gYWEB09PTWFxcRLlcxtTUFAqFArvDNCmlOM8QESXOL9OgIyiA8uui0em+uTUIyCbdLJtOvZeTV2ap38Fn6oMhawmN0dFRHDp0CPPz83jve9+LI0eObBZNkzlr0sVW2Ok6iYhi0OuopTDHMDkPvSGKUXppua6piyRyuRyKxSLm5+c3J0e0Zok+fvw4JiYmMDU1taUXUe0HpdRmETUzQ4MpTB96Wn7xZJXxr6ys/45rt7uLaRlMmdxo6G9fLHbW3jJZ4qXR0F//olQCtm3TP36zqX/sbntqNf31uNbWgOvX9Q8PdF6CF6/fJ1EWsduPMTQU/FrD/sikKhiylsQYHR3dnDX65MmTOHnyZObWDoubNekiR5OlR5jgxnydU/1zCNTgL30R48KuCmYLu2Y9rjGlIJB2G1he1g8QGg3g2jX9BarGxoCFhcA3Z/OG3Gx2IopGQ/v41zCOhuYKG6USMDph8HN38yaq1y/pbQugOL0dZ8+arWU2MXHrY7r1WEBvf3y5zS9VLHb+BbU5jFQFQ8AbcwZVq1VMTExgYmICk5OTm0EQ9U4pdcs/IjdZrpGIE7NzehmDzefbbbPMUKtltr1tW6/6o1vaalhaYJLsaTbfWAvM6ASarzeXM7+cTkHD4nvJBpmOTIuyyDpVf6tY9UHFYhH1eh1LS0uYmppCsVhkbVBErADIGk3GmiEi6re0BoQcSu/OLWvtFTA6M0V+x3I+rzORpurmi6KWqmAIeCMgGh4eRrlcRj6fZwYjQswKEVHa9GOG4TDnT7pdXm1IQ7uA29vhXGXePgTf7bGg47k97uw6i0qq0i1WHcvVq1fx9a9/HU899RT27t2LvXv3olar4cSJExgdHd2cb4jMWaPI2oNeC0JEW4bJXDRxn1/n8biZThcQN902+I3s0xmeb/o+RHkdUhUMWXPfXL16FQ8//DBEBLt27cLu3bvxpje9CXv27MHw8PDm3ENkRimFVqvFYIiIUotdVOEXNU2jQWlzqoIhO+tmvbKygkuXLuGll17Ct771LdRqNSwuLmJqagqlUgmjo6OcaNGAfUg9ERENjkEIKpziaHMci+mmNhiyXLx4EVevXsULL7yA733vexgfH8eHPvQhvOUtb8Hi4iIOHz7M4moDzWYTGxsbnF+IiBLldhMblCxCv6XhusTVhrAzjluialPqowhryYi1tTWsrKzg8uXLOHfuHOr1OkZGRnDt2jUMDw9zdXoN9pFkDISIKEl+65H1++bvVaOTxiAkqTbF9d4EDdV3fu8swM5MMGSx6olWVlbw8MMP4+mnn8b27dtx4MABzM7O4n3vex/m5+cxPDzM+Yh8bGxsYH19HU2TWU6JiGKShnWpTAt6+8kZpCVd1G26/IbO/ENuz5msKWc/TlgDEwwBnTqiRqOBM2fO4MyZM6jVajh79iyWlpZw/PhxzMzMcHJGH/YCas4vREQ0GNISlPXyXNj9TfRynIEKhpxWV1dx4cIFtNttfOlLX8Lp06exd+9e7Nq1C5VKBXNzc6wncrDXDFG6+M2/4SXMoEqjXximJ+jH58pkHamY18vgoNaY5XKdNSpM1horFPSnfC6XO9vrajaB1VVgfV1v+2oV5fma9imClppw3aFa1d48lwOmp/Uvp8Ghb5lHKEr96hYc6Ejhxo0bWFlZwY9//GM8++yzGB4exv3334/3vOc9WFhYwMTEBKom7+YWp5TCxsYG1tbW2E2WUmF+6HUDqFuWN9CRyxkFZ33569Uk+rDWHtDVbhsdP0zwSno2b4C5nNkdGeg5APZdib3ZBK5e7axPpmNkBCM7NlAqxdRbUSx2FoLVlAOwY4f+4d1+HKKc+0in60z3uL0GTQMdDFndPq1WC+12G+vr6zh//jxeeuklNJtNzM7OYmxsDJOTk6hUKpuzW2eV83rR1mD0C4Dve6TS0H0xyHRHlBkVEXeDeLftvYJXr+Lg22p1rGyjYZBtP77zvG7n9KNzLfwCllxOf6FVt7YE1ev0s8vL+f5kpmbIj7X6+re//W0899xz2LZtG772ta9henoaH/7wh3Hs2LHNJT6ySimFRqOB1dVVbGxscEQZESXKHgyYZAKCtvEqvnW70fuNkoo62NXJqIR9bW6PBb0mk6JlP2GzMr1e3yjfry0TDAGdAuvLly/j8uXLuHTpEtbW1jAzM4N7770XKysrAIBisZjpGaxZQE1EaRI00sjaJo7zxn2OpOlc216YdmXpHi8JWyoYsltbW8P58+dx48YNfPazn8UjjzyCvXv34tixYxgfH8eePXsyV0+klML6+jpu3ryJjY2NpJtDRATAfNkJnbmJepnMLw1z+3hlrvy6AN2uifOYQa8jqGssynmh3CZQ1DluHO/Hlg2GGo0GLl68CAB4+eWXkcvlcO+996LZbGJ+fh71ej2TwZDVTcYCaiJKK92uIp3uIN0bZz+7y5x02u81RN35eFA3mMl8P37t8juPrqBuQ68gOY73Y8sGQ3ZWPdHFixfx9NNP4+LFiyiVSpiamsLi4iJqtRry+fyWn5/IGk22sbHBbjIiSlSvf93rTOYHmHcVJdFN4xeA6GTIwp7L7Tm3omTTYuY46GSJWEAdwBpF9cMf/hDnzp1DuVzGww8/jPHxcXz0ox/F+9//foyMjGBsbGxL1xJZ3WTLy8tYX19nATURJSaKQMjtOElkdqLkdcN3ey6Orryosjwm7dHZ1uv5KDJUQEaCIcv6+jrW19exurqKYrGI5eVlvPLKKzh//jyq1SpyuRyGhoZQLBaRz+eTbm4srAJqDq0noqTo1q54ZSb8MgSmXUFe5/Q6TxgmNUhuNTO63Xy9ZnF0sy8m3Y5e57dvE7YuKMpsVKaCIcvGxgYuXryIq1ev4nOf+xweeeQRLC0t4Z577sHU1BSOHTuGubm5pJsZuXa7jdXVVSwvL6PRaCTdHCIiT343d9Mh417beT0XdSYpKJjz6pqKsgtMZ7ugGh6TcwBmEzSadA+GaUuQTAZD7XZ7c6j997//fTz++OM4dOgQxsbGsLCwgN27d6NWqwEARLbODLNWzdD6+jpHkxFRYnSzN7o37V5Gjuk8F3c9TK8BR9zCdneZZHZ6rUvK9AzUUbDqZl5//XV85zvfwY9+9CPcuHED8/Pz2LNnDw4dOoRCoYByuTzw9UTO0WSsGcqgGD/DCgIZ8J+RuNcyozeYZG/CzEPkt09QwbLnTb1a7axnoTsat1QCrl+P77MyNobrN4dMVtgxUir5r5fWy9B33aBTN2DqNVjNfDAEdIKE1157DRcvXsTQ0BAee+wxjI6O4oEHHsDMzAyq1SqGh4e3RDC0traGlZUVdpP1kelfbqa/2Pr5F6sf1f1bPq7jh2LyM2taR2e4lhmFE/fsxkaBV7UK7N+v34jr14ELFwDdTLxprWq5jEuXhrRjs0LB7CM7MeEfDPWS0fINOgOOGUf2jsFQl1JqM1ty48YNtFotnDt3Dk899RTGx8exc+dOVCoVjI6ODvSSHtaq9RxaT2mQ5IyzlH6mwbXXTRLQnzgwsBA5YHHXW/Y1XSzY9PeyYQBvGr/7Hd4vINGp9+rlZ9/tWjMzFLFWq4WrV6/i+vXr+PKXv4zHHnsMtVoN73znO1Gv13H33Xfj8OHDAAavnsgqoL5x4wbW1tbYTUZEqRbXUHG3G2gvQ7SjGt49SIKyOEFdlHG9t2ExGHJhFRe/9tprOH/+PC5fvoylpSU0m03s378fq6urm5M0ishABUXW0HoGQkSUlKgzgm4F1710pXhleryG3kexNEXahZ03qJflO7ymOPDLAIbFYCiAUgrXrl3Do48+iqeeegpnz57F1772Nezduxdvf/vbUa1WMTo6iqJfx2pK2NcmW19fT7o5RJRRYUcnBR3PrdskTFeKVzeO13GykBnS6dpyC0rt18xkygBn4KnTvl4wGNKwsrKCJ598EiKCM2fOYGxsDPfddx/279+PVquFkZGRgQmGGo0G1tbWuDYZEaVKFBkVv64bnYkU3QKnqAO3QeQXxJjMBm7yXpgEtVFcewZDBqxgYmVlBWfPnsVDDz2Eqakp7N+/H5OTk5iZmcHs7Gxqu82sIvFGo8FgiIhSRXckkZ3JTdAkwxTGVg2EAP0h7brzDPU6OjCObkkGQ4ZWVlawurqKRx99FE8++STGx8fxrne9Czt37sSpU6dw3333IZ/Pp3IYvn1o/cbGBuuGiCgRJstTmOzjN1IpqM5E9/xZqA8KK+z7YXod47j+DIYMWYu+rq6uYnV1Fevr63j11VdRKBTwyiuv4NVXX0WpVMLY2BgKhQLy+XxqMkVW27k2GRElya/mRmefoGUegrJMYZa7CBqBRrfTfT96HWIfBQZDPVpdXcV3v/tdPPvss3j66afxla98BUtLS/jQhz6E2dlZTE1NoVqtJt3MTawZIqI0MR315ZdRCFPg67VvmKxDFjJFbtcJ0K/j0X2839eSwVCPms0mXn31VQDA+fPn8cMf/hCHDh3C3XffjVKphGq1ikqlkorskJUZajQanHRxC0ndrM/kS+f9ytJ7ZForFJRRCLq+bs+7BUjR1LWgM8thXL9vczm022ZzL/baKaB7nXp9XCcY9nvMFIOhCDUaDSwvL+Oll17C5z//eczMzOCOO+7A4uIi5ubmsH///s25iZJgFVBzBup0S0u5Wa/zdgRJ3Q2/Dxde95pu9QyDTr2P6bw2FtObvdvb7jfaSTdrJVCdtSy2bes9AvHw+s0RPPssoLu6UqMBrK3pNSeXA44c6SzJkcsFj/4C9GaXNq0fcpvbyXke5yi1MBgMRajRaGyONnvppZcwPDyMe+65BwcOHMCdd96JHTt2bBZXJxUQWavWc+JF0mG6bqnxDTzMTSIt0aKhuIPLrUI3IPKaU8gkU5LL3fpx0hny7cW1zaVS519MXvwucPq0fjD0+uudf7rBUKEAHD/+xs92UIBqfz/CjPTz6oKzb+M8j9txwmAwFIN2u71ZoHzp0iVUKhVMTk7i9OnTGBsbw/z8PMrlMoaHhzE0NNS3diml0G630Wq1GAj1UZi/bjMh7F/LcS3RHaPMvbcB3G6WOjc7v2NY1zjMx8qkoDqom6eXQMr5mN/x7IGfbgmoUp01Y3V+/Yu8cS11X5szQNWtA/K6/n7bRp09ZTAUo2aziR/84Ad48cUX8b3vfQ8PPvgg6vU6Pvaxj2H//v2YnZ3F7OxsX9tkzwwRESXFpBtFZzt7V0pUbQk6r+6UAPb26da7mHbRpUFQ26IIFN2ygVFcEwZDMVJKYWVlZfPf9evXsby8jFdeeQVTU1ObQ/BzuVxfaomszJA9c0VElCamXStR8atVCcpgha2VsY6he0NPMhAKU7gc1OXpVvMT5vpFgcFQnzSbTaysrODVV1/FH/3RH+HrX/867rjjDuzbtw/1eh0nT57E6Oho7PVEnGeIiNImioLbXrsig7q//NroF9CYBDk6NUtJZYf8Xptf95fO/vbvdbvBnMfu9bowGOqTVquFVquF9fV1PPzww8jlcnjhhRdw7tw5HDp0CEeOHNkcgh9XMGRlhFqtFoMhIkoNnaJcr8ecN9C42hRHF5DOMfwyU2kRFEiGOZbX/70c2w+DoYQopXDlyhW88MILaDab+PKXv4zp6Wns27cPtVptc46iqAMjFlAT0VYTd4DQr2yMW8YrjcFPnEynVGA32YBTSuHcuXN47bXX8Pjjj+ORRx7BxMQEPv7xj+PUqVOo1Wool8vI5/ORntfqJmMwRERpllR3kNt5TdthWmRtP88gB0FRvGcm+0dVQA8wGEqU1XVm1fA0Gg28/PLLOHv2LFqt1ubw+9HRURQKhUiyREqpzX9ERHQrtyDGtKapl26tQQyCLGFH5SVxficGQynQbrexurqKZrOJL37xi/jzP/9z7Ny5E0eOHMHc3Bzuv/9+zM/Po1AoIBdi7hTnAq0MhIgoSTqBRtRDp03b5daWoO3DtjXtQ+bTFrjEgcFQCljBSqvVwvPPPw+gM1ljs9nE0tISTp06henpaQAINQTfng1iIEQUHU6mGI7fyCPdkUFeAVUu19vEi0Ft9OvK8hr1FhT8OUeTxaXd7ky4qDsDtcXtPTFdVkN3G5P3njVDGXDt2jX84Ac/wMWLF5HL5TA7O4sjR47g4MGDKJfLmJmZQaGg9/ZZa5KxcJpMmSQijX8phZkhOkOjILMSaLmNFtLpZvLaxrnEhmk7LH5Bi85n3W25EOfXzuHhzab+2mFAZ+bpsTH9FT9eew147jm9GatzOeDChdtnoba3VyfgMWEaBEeZXWIwlFJXrlzB1atXkc/n8cQTT2BkZAQf+chHMDQ0hJmZGUxOThoFQyycHhxpWW1CoPknZFi5nNEN3/gXX7udqiU5wshQ7OfJ9MYa5i33Cnx6GdlkclO3rK8D167pLZcBAK0WUK3qL8dx8yZw5ozeWmZWMORHNzPm3CbsnExxdicyGEoxK4hpdD+5586dw+OPP47Z2Vm0222Mjo6iVqthbGzMd34i+8zTDIa2nrT1vRPpcM4N5NWdpNuN4jbBn/PY9ue89vU6j7Nrxnm8oODJr0vIfn7dbixL2ExYEGcbvNpvue11eHSHBb1/pl1kzmOHxWAo5ZRSaDQa2NjYwEMPPYRvf/vbmJmZwdGjRzE7O4uf/dmfxbFjx1AoFDwXfVVKYWNjAxsbGwyGiChVvG6SXsGFV91KUKbBtDsnTBdZUF1QcNdZertGdTI5pl2abu+3bhvcPh+9/GHIYGgAWIXP165dw7Vr17C+vo6xsTGsrq7iwoULuHLlCkZGRlCpVJDL5ZDP52/JElkZJmaGiCgtgjJA9m2CjhEkqFsmzE1UJyjSeTztI8ksuu2MumvRL2PEmqGMW15expkzZ3Du3DksLy9jbm4OR48exalTpzA2NoadO3eiXC5vbm91ta2vr3MZDiJKFa9sil93iJ3JMP1ehZ1M0euGPiiBEKA//5JfN6H1vOnr7sc1YjA0gNbW1vDaa68B6NQRFQoFXLlyBXNzc6jVaqjX67cEQ+12e7ObjMEQEaVRULeUaRdMHMIEQvb9dB9PM53rrTsRpc7r99uGQ+tpU7vdRrPZxNmzZ/HNb34TU1NTuHTpEiYnJ7Fnzx4sLCxsBkIcTUZEg8T0ZueWtdDNMJnwqlsyFcd8OXHSbadXAbvXe9PPtnlhMDTgmt0xlU888QSeffZZjI2N4eDBg5iensZHP/pRTE1NYW1tDWtra+wmI6KBYnpz88s+9FIfpHvOsPumPRDyq+vy4xx15zxOrzVUUWYFGQxtEVb2BwAuXryIVquFs2fP4rnnnsPGxgZWV1dx/fr1zW2IiJJiOgQ9zHHi3DfMuSxpD3zcmNYB6Uw46XesoOfieO8YDG0x6+vrePHFF/Hyyy/j0qVL+MIXvoCZmRns378fjUYDr7/+etJNJKKMcyskth4PW4eis73zOb9i4DA3XN0C7kHpFvPjNRLMbd4fZ4bIjUlRdhzXjsHQFtNqtbC8vAwAuHHjBp5//nksLi6iUqmg3W5vTuBI/ZOWZRVM2zHov6xpsEQ1jF5ne3vWwt51E3UNS5jnRcwmUTSZdDGfBwoF/bXJ/BY58ApwdL6285rEUgcLqEmLtRbZ5cuXcfr0abTbbVy9ejXpZlGAVK0gkarGIFXt6UeQm6KXG6ugG1qcmRSv7EYU2m29pS/sRkf1t925s7O9TnDTbgPT08Cb3tRZxkPHqVO3BkRB8wL5dWcFvYdh6oe8zh8Gg6EtzJps8fLly7hy5crmY0RpYf+LMGlpaUdWmcwGHbR90HZhbsw6nIFCuy1oNPSX1xga6iy8qmtsDFhY0N/++HHggQf0t3cG46bZO5PASed4QTiajAIxCKK0SkN3XC+BkO4NOc7jbwWmBdV+GYcoCrRNJnv0eyzMAN64hpvnAzKNftMR+LUrTOYuyWygm4wkYYmIaBCFqSXyy0iYdq0EZS/dRoqpbhVSvznPGTZAcfs/6kya1/XRyRjZ943qOjMYIiKi1PG64QXdRP2e8wtS/AIJ00AgKHgIYm+v7rYmxw3bFuf+ft+HfZ+cI/rczqv73phgNxkREaWO6Q1Pd/SYyXOm54uqa8evTX5FzEFTA4Rpm1dbgqYi8Gu77hQE7CYjIiJykeYaqn60TfcccbclTOASNvDsBwZDRESUWm7dKrqPeT0fpvsp6i6rsLzaZdot5dxPt2suytcY5n10bmPSpeiHwRAREaWKW1GyXdDoMjfOLhyTAt6g0Wm6bYiCV7u8zu3c3vm41/8654+DaZdoVNkmBkNERJQYt0yH34gvv0yAW7GvbpGvaSYobFajF26vyVlg7Bbo+QV+QQXSzuf9rp9blkknc+P3ukze516uPwuoiYgoMTq1J72O7NI5ll+GxG1OI7/tgobjh+UsPva6Fl6vWfda9Pp8L9fQ73w6xw+LmSEiSpT9L0C/f2nUj2LWQbsmOnSyNvbHdLJHfsdxO67XaCev7b32CTp3mCVVTN7bsLVCYUTRLj9+GcG4MTNEFDPdG2EUvzyCtk3bDdT0l2tc9QppGgVkSdt7FSVnBsXtf+e2OnSHbHvV1ZjUn9jPZa8zsh8jlxOUStrN3wycvOqC3F6fV1DndU1Nfh85z6tTR+VWc+XVriBer9vrOOwmI9oC+hGspDEgMhFnQJQ2g/5e6Qi6ufsFN377+t2I3Z53u7kGfdacAZuVwbI/nssBxaLnIXy5BSBB7XLuE/R6/Y4RxOs62T+3XoGtSUDk1n7n6/K6ViYYDBFlTFaCCUo/nZoUt5umaYbBeSyvG7hJ0OB1fOdjXsKcL6gtOgGOV5bFfgzndfK71vbXbZJ9CgpYvZ7zylj1+ocSa4aIiCi1/Lq9TOqGvLb36tbxyjT4ZetMaoqCuvP8ggLTjKHfcXWur1uXoHN7ne5Jk3YGtcnv6zAYDBERUV85b+imN3i3Amnn8aLMgNqP7QwKdNsdtJ39eH6F8l5dZ17HdLvOQcXVbs8HFaV7vSder8fZLq826D7XK3aTERFRX3nVlQR14Xg95txH5/xuX+ts73wsquyHbr1TmGMGbRdmv6B6Hb/MlvN5r7oir3OGvfZ+mBkiIqJEeBXYut0wg0Yp2Y/hDLb8trc/5pU18Quw/I5l59fNFNTWoMAiqrY6r7fOsYICUedr63V73ettipkhIiLqO51Mh1/RbNCxdDIMYdtjeiz7fmHP7fWcV0CpeyzdrFKvx9d5H53bez1n8pp1MTNERESJ8vqrPo7uEL/zBT2n2w6vrFDQ8XW5dTEGtSHoWKbP2bNvupwBTNhrEZQdDIPBEBERJcqvC8lrWz9uhcN+2zqPb3pj9SveNj239bhfgbJbkOgswA66Tn7djs7zmDxvEoSFCXL9Cst7IUpFG3ET0RtE5CKAl5JuB21ZO5VSM0k3wgR/JihmoX4mGAwRERFRprGbjIiIiDKNwRARERFlGoMhIiIiyjQGQ0RERJRpDIaIiIgo0xgMERERUaYxGCIiIqJMYzBEREREmcZgiIiIiDKNwRARERFlGoMhIiIiyjQGQ0RERJRpDIaIiIgo0xgMERERUaYxGCIiIqJMYzBEREREmcZgiIiIiDKNwRARERFlGoMhIiIiyjQGQ0RERJRpDIaIiIgo0xgMERERUaYxGCIiIqJMYzBEREREmcZgiIiIiDKNwRARERFlGoMhIiIiyjQGQ0RERJRpDIaIiIgo0xgMERERUaYxGCIiIqJMK4TZSQQKAHLdUMr5v99zUewz6MdPY5t4/MFr06Af322f7q8WoN12/9/vuSj2GfTjp7FNPP7gtWnQj++2j1ICH8wMERERUaYxGCIiIqJMYzBEREREmcZgiIiIiDKNwRARERFlGoMhIiIiyjQGQ0RERJRpDIaIiIgo00QpFX5nkV9TSv2fEbZn4PGa3I7XxB2vy+14TW7Ha3I7XhN3vC63070mvWaGfq3H/bciXpPb8Zq443W5Ha/J7XhNbsdr4o7X5XZa14TdZERERJRpDIaIiIgo03oNhtg3eTtek9vxmrjjdbkdr8nteE1ux2vijtfldlrXpKcCaiIiIqJBx24yIiIiyrRIgiER+VsiokRkOorjDToR+Qci8riInBaRB0VkPuk2JU1E/qmIPNu9Lp8XkYmk25Q0EfmIiDwlIm0RuTPp9iRJRO4XkR+IyHMi8t8l3Z40EJF/LSIXROTJpNuSFiKyKCLfEJFnuj87fyPpNiVNREoi8hci8v3uNfnvk25TWohIXkS+JyJ/GrRtz8GQiCwCeC+As70eawv5p0qpo0qp4wD+FMBvJNyeNPgqgCNKqaMAzgD4VMLtSYMnAXwYwDeTbkiSRCQP4HcA/CSAQwB+QUQOJduqVPg3AO5PuhEp0wTwN5VSBwGcBPDX+VnBOoB3K6WOATgO4H4ROZlsk1LjbwB4RmfDKDJDvw3g1wGw+KhLKXXd9m0FvDZQSj2olGp2v/0WgIUk25MGSqlnlFI/SLodKXAXgOeUUj9SSjUAfAbAhxJuU+KUUt8EcDnpdqSJUupVpdR3u1/fQOdGtz3ZViVLdSx3vx3q/sv8PUdEFgD8FIB/qbN9T8GQiDwA4GWl1Pd7Oc5WJCL/o4j8GMAvgpkhp78C4MtJN4JSYzuAH9u+P4eM3+AomIgsAXgzgEcTbkriut1BpwFcAPBVpVTmrwmA/xWdRE1bZ+NC0AYi8p8AzLk89WkAfxfA+wwat2X4XRel1BeUUp8G8GkR+RSATwL4+31tYAKCrkl3m0+jk+r+/X62LSk614QgLo9l/i9b8iYiVQB/DOC/cWTiM0kp1QJwvFuL+XkROaKUymytmYh8EMAFpdR3ROSdOvsEBkNKqZ/wONmbAOwC8H0RATrdHt8VkbuUUq/pNnpQeV0XF/8PgC8hA8FQ0DURkV8C8EEA71EZmdPB4HOSZecALNq+XwDwSkJtoZQTkSF0AqHfV0r9SdLtSROl1FUReQidWrPMBkMA7gXwgIh8AEAJwJiI/N9KqY957RC6m0wp9YRSalYptaSUWkLnF9pbshAIBRGRfbZvHwDwbFJtSQsRuR/A3wHwgFLqZtLtoVR5DMA+EdklIkUAPw/giwm3iVJIOn95/ysAzyil/pek25MGIjJjjc4VkREAP4GM33OUUp9SSi10Y5OfB/B1v0AI4DxDcfnHIvKkiDyOTjdi5od/AvgXAEYBfLU75cDvJt2gpInIz4jIOQCnAHxJRL6SdJuS0C2s/ySAr6BTEPuHSqmnkm1V8kTkDwD8fwAOiMg5EfnVpNuUAvcC+DiAd3d/j5zu/vWfZXUA3+jebx5Dp2YocCg53YozUBMREVGmMTNEREREmcZgiIiIiDKNwRARERFlGoMhIiIiyjQGQ0RERJRpDIaIyJOIfLq7Evbj3WHMd3cff0hE7rRtt+RcXV1E/rmIvCwiOdtjvywiF7vHelpE/loEbXynzqrUREReAmegJqJsEpFT6MwY/hal1LqITAMoau6bA/Az6Kw5dh+Ah2xPf1Yp9UkRmQXwlIh8USl1PtrWExHpY2aIiLzUAVxSSq0DgFLqklJKd5mMd6GzHMD/DuAX3DZQSl0A8DyAnfbHReRRETls+/4hEXmriNwlIo+IyPe6/x9wHlNEflNE/pbt+ye7C3pCRD4mIn/RzUr9HyKS13wtRLTFMRgiIi8PAlgUkTMi8r+JyDscz/++NQswgD9zPPcLAP4AwOcBfLC7ntQtRGQ3gN0AnnM89RkAH+1uUwcwr5T6DjpLDNynlHozgN8A8I90X4iIHATwcwDuVUodB9AC8Iu6+xPR1sZgiIhcKaWWAbwVwK8BuAjgsyLyy7ZNflEpdbwbXGwuidBdX+wDAP59d0XxR9FZlsbyc90A6g8AfEIpddlx6j8E8JHu1x8F8Lnu1+MAPtetTfptAIeh7z3d1/JY99zvQScQIyJizRAReVNKtdCp93lIRJ4A8EsA/k3AbvejE7g80VlXE2UANwF8qfv8Z5VSn/Q558si8rqIHEUnm/OJ7lP/AMA3lFI/0+36eshl9yZu/SOv1P1fAPyeUupTAW0nogxiZoiIXInIARHZZ3voOICXNHb9BQB/VSm11F01eheA94lI2eD0nwHw6wDGlVJPdB8bB/By9+tf9tjvRQBv6bb/Ld1zA8DXAPzlbtE2RGSbiOx0PQIRZQ6DISLyUgXwe90h8I8DOATgN/126AY878cbWSAopVYA/GcAP21w7j8C8PPodJlZ/icAvyUi/y8Ar+LnPwawrdsV9l8BONNtw9MA/h6AB7uv5avoFIgTEXHVeiIiIso2ZoaIiIgo0xgMERERUaYxGCIiIqJMYzBEREREmcZgiIiIiDKNwRARERFlGoMhIiIiyjQGQ0RERJRp/z/LD9CTYczfogAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 720x288 with 4 Axes>"
-      ]
+      "text/plain": "<Figure size 720x288 with 4 Axes>",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjwAAAD/CAYAAAD17AypAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAA2t0lEQVR4nO3de5Qb130f8O8PwAJYAPteLBb7IJfkkhQfJimblEjKku04shTbsRI7luPabuwkdXJOfZL2NI/mcRI3aV5t2qSnTZu0Jzl1cnwcxXZcO7FdK7Es2TmqZMkWrQclUU9SlPgUn7vcXSyA2z+AgSAYGNw7mMEMBt/POXvIBe7M3BkAOz/c+7v3ilIKRERERGEW8bsCRERERF5jwENEREShx4CHiIiIQo8BDxEREYUeAx4iIiIKPQY8REREFHoMeIjIMRHZICJLIhLtwrGUiCx6fRwit4nIh0Tkbofb3isiP+12nfoRAx4iaklEXhSRH2z1vFLqhFIqo5QqdbNeRL1EKfVppdQ7/K5Hv2PAQ0SOiEjM7zoQ9Tp+jrqHAQ8RNSUifwVgA4C/q3Zb/VK1W+mnROQEgHtEZKH6WKy6zcdE5EkRuSoiz4vIz9Tt760iclJE/o2InBWRUyLysbrnJ0Tk70Tkiog8JCL/XkT+qUXdEiLyhyJyQkTOiMifisigx5eEqC0RmReRvxWRcyLyqoj8NxH5aP17ufqZ+Zci8gyAZ6qP3SEiR6rv/+dE5PYW+//J6mfsooh8TUQ2dunUeh4DHiJqSin1EQAnAPywUioD4G+qT70FwA4AtzXZ7CyAdwMYBvAxAH8kIm+se34awAiAWQA/BeBPRGSs+tyfAFiulvmJ6k8rvw9gG4B9ABar+/sNszMkclc1l+3vARwHsIDK+/KvWxT/EQA3AtgpIjcA+EsAvwhgFMAtAF5ssv87APwqgPcCyAL4FoDPuHcG4caAh4hMfVIptayUWml8Qin1ZaXUc6riPgB3A7i5rsg6gN9SSq0rpb4CYAnA9uqN4n0AflMpdU0pdRTAp5odXEQEwMcB/Gul1AWl1FUAvwvgx109SyJzNwCYAfCL1c/IqlKqaSslgN+rvn9XUAn+/0Ip9Q9KqbJS6mWl1FNNtvnZ6nZPKqWKqLzv97GVRw8DHiIy9VKrJ0Tkh0TkARG5ICKXALwTwGRdkVerf6gt1wBkUPm2GmvYd6vjZAGkAHxHRC5Vj/N/q48T+WkewPGG93gr9e/veQDPaWyzEcB/qXvfXwAgqLQkURsMeIjIjtJ8DCKSAPB5AH8IIKeUGgXwFVT+ILdzDkARwFzdY/Mtyp4HsAJgl1JqtPozUu12I/LTSwA2aCYi13+OXgKwRXP/P1P3vh9VSg0qpe53Utl+w4CHiOycAbBZs2wcQALV4EVEfgiA1lDc6rD2vwXwSRFJich1AP55i7JlAP8LlfygKQAQkVkRaZZTRNRN3wZwCsDvi0haRJIicpPGdn8O4GMi8nYRiVTfz9c1KfenAH5FRHYBgIiMiMj73at+uDHgISI7vwfg16vN5z9mV7CaS/NzqCQ3XwTwzwB8yeBYn0Alofk0gL9CJRlzrUXZXwbwLIAHROQKgH8EsN3gWESuqwbuP4xKIv0JACcBfEBju2+jmuQP4DKA+1Dpvmos9wUAfwDgr6vv+8cB/JBb9Q87Uapp6zQRka9E5A8ATCul7EZrERFpYQsPEQWCiFwnInuk4gZURq58we96EVE4cIZHIgqKIVS6sWZQyR36TwC+6GuNiCg02KVFREREoccuLSIiIgo9BjxEREQUeo5yeESE/WDkKaWUzmR1gTE5OakWFhb8rgaF1Isvvojz58/zM0FU5eQzwaRlIhcsLCzgoYce1i4vzScrbklpTVbc2TE8VS7rl41Eev98Deic64ED+7tQE3ctLCzg4Yce6vpxFaRn3wu6/DhHu2M6fc702PX72n/ggPF+2KVFREShEfZgB/DnHO2O6fQ502N3ui8GPERE1HVOWvF68Zid6sU6BxUDHiIi6gvdahnxOkix27/usa1yzcq7WX+7/Zsep9N6MeAhIqKu8zr4cOOm7XQf9efWaT2aXSc3upDsuoncfG3s9m96HHZpERERNXAzd8TvfZA7GPAQEZHndFo6dLpXTLtsTLjRVeRkG6fn6PR4duV1u5vceh2cdm85wYCHiIg8Z7V0mN7YGltITLtsmmlVB7dHGzmtq9NWISddRI3XonH4t9Nj6b7Obo3A0sGAh4iIusbrIcyd1qHfeJXD081ARhcnHiTygdfNt0H6I9MtnbYcuLFPk333g6BPAthJ/YJ+bqaCcj5e1oMBDxF5LxIxm205YAwniubcKVVBuIHa6aR+QT83U0E5Hy/rwYCHyCe6N9FIteM5KH+QHIvo96DrnmuYAouef30N1X+TD0rrQq9pdt28upZu7VdnP63KdFoH5vAQEVHX1d+4nCQYd5tJPbwaSdYqwbjxsW4zGd2mU79WZTgPDxERhVZQWn5M6uHGSDLd8kFI9A5CIroOBjxERER9ppOWs27NE+Q2BjxERER9xo+Ebb9bexjwEBFR17WbYVdBaj922+sex3Rbr/ffbp86517/vOk5mdTbyYzMncxa3ercO72uHKVFRESesBtV025iOjdm+rXCBtNtdcu0KtdpS4aTY5uek0m9nSwAajcCr9PX1im28BARkSdMlh/o9Ft/476aDddudyy7Mk5bLJrts9V56D7ebHRWs21MWojsjmt3LTpp4WmsY2O9G//tNBBiCw8REfnCpIXCpKXIjVYdk1YJ3efsWkVMWlfazUfTbt0ynWUfdK+Fkxa8Vs+ZtgSZYgsPERH1Fb+TZzvl1bD3oHLrPNjCQ+QTg4mHu/OHy3Tq5wBo902W/NWNGZQbj2F6TCd1bOxisdtH0+fK5dd+dMRirnzu2p2r9XxQZ77utF4MeIh8Eqg/KCaLRZmuidWFAMnLa2lyX7IEKCb0VTeWIuhWgnDjNvVBtnGCbrEILC3pv7GSSSCTsS2iEww0Cwzrt3N6Lb0OkOwS0E0w4OkDItXELxWgG2wIeRrA8I7bcwIV0Pqo04RTu5t0s/W4WpW3q4PdmlStWpDalbdd56pcrgQ9up9rjXKN18HuGtWXb1bXxu0bj9HuWjQr02p/repnd25OMeAJuXg8jmQyiXK5jLW1NZTLZZTLZQY/ROQ525u+A81u1o3P2ZVvt1+dbXWTdN08bxOm16hdkOG0da1ZENVsG50EaN3n22HAE3KxWAzJZBKlUgnFYhFApaWHAQ8Rec1kNFLYBfW8vapXp91kXmDAEyKRSAQDAwNIJBLYvHkzxsbGkM1mkc/ncfbsWXzjG9/AhQsX/K4mEdHrBDVJ1qlePZ+g15tdWlQTi8WQTqcxPj6O2267DTt27MCWLVuwa9cuHDlyBE8++SQuXrxYy+khIgqCIN9knejV8+n2iDpT7NLqY5FIBJFIBJlMBqlUCqlUCpOTkxgdHcXc3BxyuRyy2SyGh4eRTqcRiUTYnUVEgeNFy4LOPu2Smlsl05oM3fajxcTkmPXn3WldW23fjWkCdDHg6VHRaBSpVAqJRAI33XQTrr/+euRyOezcuRPpdBrZbBbpdBqJRKIW6BSLRRSLRQY8RBQojuez0dinTpnG0UON2+sk3zqtgxM6a5TplNcJ9tysj98tXwx4eoyI1HJ1BgcHkUqlMDc3hx07dmBmZgZvetObkEwmm3ZbWaOzGPAQkV/shiW3C3Z0AqJW+/d6Pp/6etQfu1ld3NJqyHhjENNqqH7jkPJWjzXuw+7xZs+1+71esyHsbl07Bjw9IpFIIBqNYtOmTbjuuuswPDyMzZs3Y2RkBFu3bsWGDRswNDSEgYGB1wU7SimUy2WUSqXa70REftEd5t2sjE7A0mr/bgY0uoGTk3PV0e6c7FrM7La1e6zVMPNm27X6XXcCQd0h9aYY8PQAEUE8HkcikcC2bdvwzne+E1NTU7jxxhsxPj5ea/Vpxgp2OPcOEfUip9/sTbvHdMubzD3TTXbBjRtdhTr70t2HaT3cWvKCAU8ARSIRRKNRpNNpTE9PI5lMYnp6GsPDw9i9ezfm5+cxNjaGZDKJSCRiO+rKauFhwOO9xhwAO8YfWq9nTo5EzGdz7lEmrxPg/NKbHsfv/IagsWsNMF1GodX+68uZ5rC0CjC0bsqRCBCP25epF2t/q9Zp1bGYLCdh1wXWbH92z7WatVqnHrpl7DDgCSBrduTFxUW8+93vxtTUFPbt24fZ2Vkkk0mkUinEYjHE4/G2Q8zL5TLW19drkw4StdTDy1GYBhemTC9ND67DGjhe5tuYBku63T86+wZQCXY0gpgagzeK24GDSXdiu+ecdvG59WWAAU8AWF1SyWQS0WgUQ0NDyGQyyOfzmJ2dRS6Xw/z8PGZnZ43n0LFaeKx/icJGQYwap4IUZJTLwaoPdRFf+KY4LD3EYrEYEokERkdHcfjwYeRyOSwuLmLjxo0YGRnB/Pw8kslkLVfHlNXCs76+7kHtiYiCwelQ6qDPLtzrvJhOwCkGPD6LRqOIx+MYGRnBrl27sHnzZuzbtw+7du2CiHQ8K3KpVKolLRMR9ZpOh5U3G7rtxSR7dpMYmu7XqyCsk8kS7Yan2+X1NF5z3QkK3V54FmDA01UiUsu92bRpE7LZLCYnJzE7O4uxsTHs378fk5OTmJiYcCXYASpdWoVCAevr60xaJqLAMB0d5ObIoE6HO9vts5Mbcrt9dGNpBtPcJNM8HN39eBHwMeDpomg0imQyiUwmg8OHD2Pfvn3YunUr3vSmN2FgYADxeLy2XIRb610Vi0Wsra1hfX29NhcPEZFfdOdi6XT/ps95zY1ju9VC1Q069TNtxeEorQCzApdMJoNMJoPBwUFMTExgaGgICwsLyOfzmJiYQDqd/r4JA92ilKp1axER+U13WHO79atadYE06zZpNvux211gOl077brCdLqzdJ9vda10rqXJsZtdz2YzK+uOdGtVt8bHnGDA4xERQSKRwMDAAA4cOIADBw4gl8vh+uuvx9DQEMbHx5FOp5FMJj0LdoBKC8/q6irW1tbYpUVEvtOZJ6bxsWbdIa320W7/OkPS7WYVttuu3eM6XWE6gZ9OPVodV+dattu3zmOtlr0wPU4n9W3EgMdlVpdU/eKeuVwOW7ZswezsLPbu3YuhoaGWMyO7rVwuo1gsMmmZiALB7URUL/bfScKx02Oa1MWLLi23E6bdaD1yGwMelwwMDCAajWJubg67du3C8PAwtm3bhtHRUSwsLGDjxo3IZDItF/b0SrFYxMrKClZXV9mtRUSB0SyXx4ubXrdyXdq1QLiZw+PF/t1IurbbbzOmMy13igGPS6zh5XNzc3jLW96C6elpvPnNb0Y+n6+1+vjB6tIqFAq+HJ+IqBnd7hGvdSsB2OtjBD2JuZlu15kBjwNWAJNKpZDP5zE4OIjp6WmMjo5iy5Yt2LJlC8bGxpBKpRCNRrvaotOofuJB5vBQK7287lOlLv59xppx8v3G6+UxwsTtIOX79lcuA6ur+jsoFCrldVMHJidx5lICuvPBRqNm76lUCshkDD6n5TJgsvxQLObKTNHdHm3GgMeBaDSKRCKBmZkZvOtd70I+n8f+/fuxZcsWJBIJDA4O1sr4GewAwPr6OpaXl7GyssI8Ho8FKQgI3FoLXr73ulD/oF3OXuZ0xJOXK5Z/X/nVVeDCBf0g4MoV4JVX9MsfPIjHH8/i2jW94rEYkEzqlQWAuTlg82YgqvteLBSgXRmgElHVVchp4KLbncnV0ruofq2rWCyGdDqNTCaD2dlZzMzMIJ/PI5/PY2ZmxrUJA91iJS2XSiW28PQ43RYA4z8I5TIQiZpXqMcDaN1EyqDuP0x0RkV1MpLI7ngtyxeL+gGMFTDoli+Xa41COkzWGQXMGmtqTD7PDWV1Xxunc+y4lefDgKeNSCSCeDyOTCaDQ4cOYWZmBouLi9i+fTsymQxmZmYwODiI8fFx3/J07BQKBSwtLbGFh4gCIQi5O4FqjaWuYcDTRjQaRSwWQyqVwubNm7Ft2zbs27cPBw4cQDQaDWSQU69UKqFQKKBQKLCFh4i6rtt5Gk4XEQ2zIJ+j3Rpa7db1MsWAp46IIBqNIhqN1mZCHhsbw8LCAkZGRrBnzx5ks1nMzMy4uvyDl6xh6YVCgS08RNR1pjda3cUl3TpeUAOBMNJp3fNyeD8DnjoigoGBASSTSezduxcHDhzA4uIi3vzmNyOVSmFgYMD1ta68VigUsLy8jGvXrjHgIaLAc5LjQfb8vHZuTzzIpGWHrATjTCaD4eFhJJNJTExMIJVKYevWrZibm8Pk5CRSqRSSyWTgu6+aUUoxaZmIiHzBiQcDwpodeefOnTh48CByuRwOHjyI8fFxjIyMIJ1OI5FI9HSwUygUcPXqVbbwEFHXBTV3JKj16iY3r4Ebw9K7oe8CHmudq2g0isHBQQwMDCCbzWLjxo2YmZnBjh07MDk52VPdVnasiQeLxSJbeIioq7xcQ0kn18dkle6w6sY1cLovu4RlL/RNwGMFOblcDrt378bo6Ch27NiBqakp5PN5bNiwAel0urawZxiCHaAy8eC1a9ewurrKgIeIAqWTCeV0cn04WiuYwZ3dOmp2k05y4kFNkUgEsVgM2WwWBw4cQD6fxw/8wA9g06ZNPTG83ClrLa21tTV2aRFRoDTmb3h1s3My9Jnaczo7ss4kg7rlTYQy4KmfGTmfzyOdTmN6ehqTk5OYnZ2ttfCErTWnGWseHq6lRS0ZBvsCFbilIoL2fcVkVmDOtmzPjaRWnaHPHd1U43FgfFz/c1EuY/Nm/ZmWCwVgbc2sSktLQCSi997KZAYhpmtpQT9wKZVFc/ZnnfpWyji5nYUy4IlEIhgYGMDExATe9ra3YW5uDjfccAP27NmDeDxeWyLCSloOM2strdXVVbbw9BMnQYyXPI5IvK6/l9Vn0POanm1pyWSA4WH98uUytk++qv3GWs+M4cQJs+8ZZ8/qlx0fBybGM/obGFpZqfzo0rkspZJ5PUIT8EQikVoSciqVQiaTwdTUFObm5jAzM4Pp6Wlks9la0nK/sNbSYtJy7+vZmwG1FebXtpPupFbbmnRDOV2s1EgkYr7glcFq7APDw4jFoiZLdRmtp1Uum10DK0A3uWam37e9+JLR8wGPiCAWi2FwcBAHDhzAhg0bsLi4iD179iCTyWB6ehqDg4MYHR1FzPQNGQLWTMtMWiYiP5jOpKuzrcnoL68ns+tHvXq9ejoCsJaCsGZHnp2dxfbt27F3717ccsstiMfjiEajoc7RaYfD0okoKJy0pHgxdNkuObrfuT0zcpD0XMBjjaian5/H3NwcxsbGsHXrVgwNDeG6665DLpdDPp+vLQPRz8EO8FrSMgMeIvKbk64lkxE+Tso5LR9Wul2GvXi9eirgsVp0YrEYtm7dioMHD2Lz5s249dZbMTQ0hEQiUWvR6fdAx1IqlbC6uspRWkQUeN26ifbizbqbwnp9Ah3wWEFLOp3G6OgoEokEstksBgcHsXPnztqK5tZaV/3efdVMuVxGuVzmWlpE5Jv6ZGMA39dF1fhYq33olHOyX87J83qm3VrdnjHZqUAHPFb31cLCAg4fPoxcLoebb74Z+XweQ0NDSKfTiMfjSKfTfTXyyoQ18WChUGDAQ0S+sEs29ruLyunMzGFmeu2cdjt2W+ACHmtGZGviQGutq7m5OeTzeWzduhUzMzO1pSLIntW6Uy6XGfAQke+C+u0fCHbdusHt8w/a/FKBCXgikQgikQgmJiZqMyHv3r0bc3NzmJycxPz8PFKpFCYmJhCLxdh1pUkpxXl4iCgw3Foeol053Tl+6sv1c7ADNF/iwzQIaryeQQp6AhPwWMtBDA0NYefOnZiZmcGtt96K3bt31xKVyZw18WDJybSUREQB0Wk3i9Ny/aiTbr4gX0/foohIJIJ4PI6ZmZnaBIHWbMj79u3D6OgoJiYmQr2wZzcopWqJy2zhCY5ufOsJ8h+esDN9fflaGSoWgWvX9KfvjcWAVEp/+t5yubKAVaGgVz6TAUZHzfZvMhVysYjp6aj26V65Apw7p7/7Zvt1s3trYABIJvXL61xGJ2GBLwGPtbzD0NBQbXbkgwcP4uDBg3231pXXrIkHOUqLWunKzdlkXvke/4IThCn0Q69QqCwWpbui5tBQ5Y6re7GLxcrqm7oBz/AwlmQI65rFBwaAzKjB52hpCYlLZ7XfXPG5jTh7Vj+mWl///secdmM1rU+88uOmngl4gNfm1MlkMhgdHcXo6CjGxsZqgQ51Tin1uh8iN1T+uBH5rFzWXzK7Cwsnl0r6AUYsZtiCYrU4aYpEunLKNbqrpvvNl4DHyteJx+PI5/NYWFjAxMQE4vE4u69cYgU51igt5vAQEVEv67Sbzbfowgp6EokEUqkUotEoWyJcxNYdIgqCVl2m1uM6Xapu5rwFadRQM0Gsn91raP00e9x0f3bl3Mgp8qWFx8oruXTpEu655x488cQTWFxcxOLiInK5HA4cOIChoaHafDxkzhqdVe5muyYRUYNWNymTUVJudos0DkXXHcbeLX7WodU1aPcaNtuHXVDj5BzduC6+BDzW3DCXLl3CfffdBxHBpk2bsHnzZrzhDW/Ali1bkEgkanPzkBmlFEqlEgMeIvKVXRDRyfwubtaHw9NfYzr3js71tAsu261a7/aK9r5PbmPdkJeXl3H+/HkcP34cDzzwAHK5HObn5zExMYFkMomhoSFONmigfjg6EZEf2gU7jetd2d3QXl+ms/o0W/fJdK0uNwWldcniZFmOdsFMs0CmVWuSV2tz+R7wWM6dO4dLly7hhRdewCOPPIKRkRHccccdeOMb34j5+Xns2rWLkw8aKBaLWF9f5/w7ROQbuy4Su9YBu324HRgEoYUnSMGOU62CGSfX16tWuMBEENbyB6urq1heXsaFCxdw8uRJ5PN5DA4O4vLly0gkElwVXUP9CC0GO0TkF7uWE5O8GS/ybNp1p3RbEFqaGutR36rWWKdWLTrNcniaPd6sm6uxbLO6NdbDRGACHouV37O8vIz77rsPR48exezsLLZv346pqSm84x3vwMzMDBKJBOfrsbG+vo61tTUUTWbzJCJymc4cLTpdWe325Ua9gtDK43drT7N62F0r3RYd3cfbrePV0zk8zZTLZRQKBRw7dgzHjh1DLpfDiRMnsLCwgH379iGbzXKCQhv1Scucf4eIgs5pgmyv0xmeHbZzbscu0ApNl5adlZUVnD17FuVyGV/+8pdx5MgRLC4uYtOmTUin05ienmZ+T4P6HB6inlIu9/R6C92e5bYvxWKVtatMpjZeXdV/X127BqysNF9zoZmrVzEyV0IJekshmU2cLEikUsDwsO4GAICJCf2JqNNp/f32cuDZE1HC1atXsby8jJdeeglPPfUUEokEbr/9drz97W/H3NwcRkdHkclk/K5mYCilsL6+jtXVVXZpdVEQJwzrWQFZkMrJH3YFMa5OWN87psPSdbu2EI8Dk5P6FSkUKitq6v49vHIFWF7WD3iSSeD0aUQ1v3hHh4dxtTio/TYvxwcwaHK+APJ5/bKN79du5Va1675yO3erJwIeq4umVCqhXC5jbW0NZ86cwfHjx1EsFjE1NYXh4WGMjY0hnU7XZnHuV43Xi8h1bMYgDTr5O7rl6ykIxORvvPV+1X3PWqkAuk0kpZLZ/qtMiuvc9OuTeqOR9gFFq2M0Szq2+7/TYKddvdzOa+qJgKeeter3ww8/jGeffRbj4+P4+te/jsnJSbz3ve/F3r17a8tV9CulFAqFAlZWVrC+vs6RWkQUKr3apeI1u5wXnWvm5fB/u2N143hADwY8QCWp+cKFC7hw4QLOnz+P1dVVZLNZ3HTTTVheXgaA2kKk/drSw6RlIgoC01aGZtsD9kPc7Y7ZL+yGcrfqFmo1BL3VY7r7bdzGblJCnYkKdc5TR08GPPVWV1dx5swZXL16FXfddRfuv/9+LC4uYu/evRgZGcGWLVv6Lr9HKYW1tTVcu3YN67p90EREHui01cDJ9mENdrRznJo8rjO0vN1j9XVo192kO9rKbrh6XwxLN1EoFHDu3DkAwMsvv4xIJIKbbroJxWIRMzMzyOfzfRnwWF1aTFomIgqHIARyndTBdFu3z7fnA556Vn7PuXPncPToUZw7dw7JZBITExOYn59HLpdDNBoN/fw91iit9fV1dmkRUU/px+4oNzlNVHZ6jE72022hCnis0UnPPPMMTp48iVQqhfvuuw8jIyO48847cdttt2FwcBDDw8Ohzu2xurSWlpawtrbGpGUi6hlBv2kGXSeJyqbHsFvZPIhCFfBY1tbWsLa2hpWVFcTjcSwtLeGVV17BmTNnkMlkEIlEMDAwgHg8jmhUb6KoXmMlLXNYOhH5yS7RWCcJuVWLhe4cP52srh40OutttVuBXndV83ZJx62O364+jXVqt5aWm2uMhTLgsayvr9dWYf/sZz+L+++/HwsLCzh8+DAmJiawd+9eTE9P+11N15XLZaysrGBpaQkF/ek8iYhcZzoXj10Z3daLbg6v9oPd6KV2Sb6NLTLtntfZxrSuJknSbrYghTrgKZfLtWHq3/ve9/Doo49i586dGB4extzcHDZv3oxcLgcAoVp93crhWVtb4ygtIgoMN2dedrpNkDjJrLCblbvTGbvbDV+3O2ZjC07jY+3258Uw9EahDnjqWXksr776Kr7zne/g+eefx9WrVzEzM4MtW7Zg586diMViSKVSPZ/f0zhKizk8vc+kZ7Jrb1+TA3nZtdrjn9d+4WQul3Y3Ou1tIhEgldJ/H8ZiQDT62ozLOpaW9N+LxSKGRkeBmF75UjyN8+f1qwJUTkFXMln5AcxnwDYp36oVym4bN4PXvgl4gEogcPr0aZw7dw4DAwN46KGHMDQ0hPe85z3IZrPIZDJIJBKhCHhWV1exvLzMLq2AMvkQK4inS0vV95V7psc/Uybq8w109UOqne48MJ6IxYwX38TUlH7ZCxeA55/XX3srkQAuXQI0exaiW7fi9OmE0Vqp8bheWQAYH38t4PGS3y1vfRXwAJVgwGr1uHr1KkqlEk6ePIknnngCIyMj2LhxI9LpNIaGhnp6eQprtXQOSyddfv8xChPdaxnWRUMbtZtFV6eLwzRR1kn3zOtUg3SjLhXd1nRr3S2DLwImS3WZLutVX9butWlMIAZad4NZ5a0yrfaly42urb4LeCylUgmXLl3ClStX8NWvfhUPPfQQcrkc3vrWtyKfz+PGG2/Erl27APRefo+VtHz16lWsrq6yS4uIfGGaSGtapl1XWKvnTG6eJnkoYWB33dslOjvZl46+Wi3dK1ZC7+nTp3HmzBlcuHABCwsLKBaL2LZtG1ZWVmoTFYpITwU+1rB0BjtE5BevAwKn+2+3nU4LVBiDHV1uTVbYyfGd6OuAp55SCpcvX8aDDz6IJ554AidOnMDXv/51LC4u4uabb0Ymk8HQ0BDiJh2jPqlfS2ttbc3v6hARfZ8gt5AwuLHn5Hp0cg0bu8Gc7osBT53l5WU8/vjjEBEcO3YMw8PDuOWWW7Bt2zaUSiUMDg72TMBTKBSwurrKtbSIKFBMb1qmQ9k73acb++9VXlxPJ8PcvbrmDHiasAKG5eVlnDhxAvfeey8mJiawbds2jI2NIZvNYmpqKrBdXFZidqFQYMBDRIFiOtdKuyHR7WYMNtln4zb9FOwA5l19uts1bq87zL3Z69FJQMSAp4Xl5WWsrKzgwQcfxOOPP46RkRG87W1vw8aNG3Ho0CHccsstiEajgRzCXj8sfX19nXk8RBRobnR32HVD6d4k+y3AMdVpV5bp9p0EV80w4GnBWoh0ZWUFKysrWFtbw6lTpxCLxfDKK6/g1KlTSCaTGB4eRiwWQzQaDUyLj1V3rqVFREHQboJBL48J6K3VZVK3fuvq8oMX15gBj6aVlRV897vfxVNPPYWjR4/ia1/7GhYWFnDHHXdgamoKExMTyGQyflezhjk8RBQUTiYY7PSGZzrs3ORYDHa858U1ZsCjqVgs4tSpUwCAM2fO4JlnnsHOnTtx4403IplMIpPJIJ1OB6KVx2rhKRQKnHiQtJkO9eQf/db6ZUJBUzorc1uc5pO0mqDQzbWaWm7j8d9/kwb7UqmyOoYpnevUSTBq+rq5iQGPA4VCAUtLSzh+/Di+8IUvIJvN4rrrrsP8/Dymp6exbdu22tw9frCSljnTcniYpoo5+QNO7nByLQOYCuiJVkGNm8OcdR7X7e7SPnYqBczMwGjtB4PFrs5cSuDoUWB1Va98sVj50fnzH40C+/YBk5NANKJ3/TptefNrXiMGPA4UCoXaKK7jx48jkUjg8OHD2L59O/bv348NGzbUEpr9Cnqs1dI5+WDwOPlge3lDNF2ry1FdgpRL5uHFdBo4srXMPTqtD2609LyufCpV+fHI8w8A3/2ufsBz5UpleS9dySSwf38l4GnFzZyaZi1F3ciLYsDTgXK5XEsKPn/+PNLpNMbGxnDkyBEMDw9jZmYGqVQKiUQCAwMDXauXUgrlchmlUonBThfxpkXUnM7NzK2kYafJ0d38/DbryrPr6imVUPvRsb5eaeHR+Z4RibQu50ayudddYSYY8LigWCzi6aefxosvvohHHnkEd999N/L5PD784Q9j27ZtmJqawpTJyrsuqG/hISLyQ7N5V3Tmcml3c3PSglO/344WFdWsg862dt1EQRgJ1qyenVwnu24snde002vCgMcFSiksLy/Xfq5cuYKlpSW88sormJiYqA1fj0QiXcntsVp46lugiIi6zek8Kp3e6E0XFTVJaHZjlW+n3W5BENR66WDA47JisYjl5WWcOnUKn/vc53DPPffguuuuw9atW5HP53Hw4EEMDQ15nt/DeXiIqF+5NfzdjYnvejlACBp2aQVMqVRCqVTC2toa7rvvPkQiEbzwwgs4efIkdu7cid27d9eGr3sV8FgtO6VSiQEPEQWK1+tfmfIjpySoQVAQutG8xIDHY0opXLx4ES+88AKKxSK++tWvYnJyElu3bkUul6vN4eN28MOkZSLym5vDj72+EZt2PYUxMHD7nNwKoNzaDwMejymlcPLkSZw+fRqPPvoo7r//foyOjuIjH/kIDh06hFwuh1QqhaiTGaJsWF1aDHiIyC9u3uz8XHXb65YPN3KFvKqHkzJu78utoesMeLrA6uaycmoKhQJefvllnDhxAqVSqTZ0fWhoCLFYzJXWHqVU7YeIqBfYrXhuOlLI7nndliedyQlNVml3Utdu0hkJ5TQwa3fNu5HIzYCni8rlMlZWVlAsFvGlL30J3/rWt7Bx40bs3r0b09PTuP322zEzM4NYLOZoFfbGRUMZ7BBRL9Ht/upkluROttPZl1stTn4FQW4Fa251ZbqJAU8XWQFJqVTCc889B6AyYWGxWMTCwgIOHTqEyclJAHA0fL2+VYfBDhFRcDS2ZgRJEMa2dCMgYsDjs8uXL+Ppp5/GuXPnEIlEMDU1hd27d2PHjh1IpVLIZrOIaa65Yq2hxWTlYOvGHzvTb5N2s62GTrns2fIS9bkGptv0Gzfms3HzmKYzAndSn0IBuHZN/zOnFJDNVrbTcfEi8OKLekt7RSKVZSjq6xK0/CcmLYfExYsXcenSJUSjUTz22GMYHBzE+9//fgwMDCCbzWJsbMwo4GGyMllMAyuTGKDnb9Km0Z1hgNTz16cL/Mhz0c1N8XpyxELh+4MMO+VyZXFP3Ynzjx4Fnn9eL0CKRIDz51//mJddfn7tA2DAEwhWoFKovjtPnjyJRx99FFNTUyiXyxgaGkIul8Pw8LDt/D31Mywz4CEiCheduNs0lne7ZTdo8yzVY8ATEEopFAoFrK+v495778XDDz+MbDaLPXv2YGpqCu973/uwd+9exGKxlguRKqWwvr6O9fV1BjxE5Ds3bn5edK/4Mcy81zkdQq475J45PH3GSja+fPkyLl++jLW1NQwPD2NlZQVnz57FxYsXMTg4iHQ6jUgkgmg0+rrWHquliC08RBQEjTlNToYvt7pZtsvHabat3RB3k+HlukO3Tc476Jqdg87EjLrLc+hcK87DE2JLS0s4duwYTp48iaWlJUxPT2PPnj04dOgQhoeHsXHjRqRSqVp5q1tsbW2NS0oQUWC4ORy73ZB000Cl1f5M5qLptFzQmLbm6G5r19rjdd4UwIAn0FZXV3H69GkAlbyeWCyGixcvYnp6GrlcDvl8/nUBT7lcrnVpMeAhon7kRqDS7zq5TqbXv5uvCQOeHlEul1EsFnHixAl885vfxMTEBM6fP4+xsTFs2bIFc3NztWCHo7SIiMiUF7lHHJZOxorV8YiPPfYYnnrqKQwPD2PHjh2YnJzEnXfeiYmJCayurmJ1dZVdWkREZMyL1hYOSyfHrFYcADh37hxKpRJOnDiBZ599Fuvr61hZWcGVK1dqZYiIgkw3+dhJcrHdvpr9X6deOtuGjd152l0np8nJXmHA06PW1tbw4osv4uWXX8b58+fxxS9+EdlsFtu2bUOhUMCrr77qdxWJiNoynQzQ6XDmViO/dNeCMtk2TEwXE3X6uN2x2aXV50qlEpaWlgAAV69exXPPPYf5+Xmk0+naiuxE5AKPlqGoF7S1ldzUak6dxnNuNn+L9bhJK4zTx9q1PDR7Xne+IDdu2CZvw2gUiMX0JhWMRCplgebn024If+NjpkGK7tB2N1qGGPCEgLV21oULF3DkyBGUy2VcunTJ72pRC04nYjNJyzK9R3v+TdW0Ql7noBnWxzQgMf0WG2aNLSLthiE3a8nptLVAZ3SQ7nD4Vo+ZtILE48D4uP7bPBYDkkn98uPjwBveAJRKeuUPHaoco9352L02rf5tRydgNNmfHQY8IWBNOHjhwgVcvHix9hgFmGH00nc56F4GSA6CHdPdm+aV9COvRu/Y3UBNZ//1qq7xeOVHVyZTCWJ0veENwOCgfnmdj4TXM1532hqkgwFPyDDQIXJPPwckXjFtAdDZV6vnGm+sjV0k7Vo03LzJ67RuNaMgiEQqQYlu4B2NVsq72XLbbl8m10r3PaDzGpnwvnOaiIioygoiuxFMNt5Y64+tc/O0K+Ok/n51dZruy658q+eatZg5Ub+d213tDHiIiKgrmgUc7W6ujQFSs8fsjlWvWRKsjlb5LO32oVu/ZufopnbXulkCuduBjRvH7vS6sEuLiIi6Qid5uNVzJsnM7Z7TeV5HJ8fQSfx1m0nydycJ4c0ed+PY7NIiIqKe0Mk39E6+9Tcr06r1yK5847925ZzWySs6rVHtrrFOi5XO6+TF+0AHAx4iIuqKZvPeuLlPkzKNSczN/rU0G03UKvnYScuIG3PMmByv/pj1z5tMFaBbxs1z6zSJnAEPERF1nemNy8tgwO9j+3Fu3TpmJ0GhW9tZGPAQEZEnOukCafdcJ3XQecxpl5Nd15DJ/txqAdNNrDZNwHZSP5Nr4wUGPERE5BvdxF6nN0qnybftWibsRjF1mvDb7jkTuonVpgnYuq9N4zBzP1vqGPAQEZEnvLqh6w5lb7Wd6bHthrjrbOtGi49T3UiEbjVpY6vn/MJh6UR+MFzewMv1K4P0B8kxjy6QNSeIV2uT6cxFExZOE06bzU7sNJDqVu6I6ZIJ9cdptuxCJGK2FEWs7s7e6vhuzCLdjRYqNzHgIeqyQN7cvFyZ1GNez3jbDUGrjxfqgzu/z9e0Dqbl3QiQ6v+NRMQo4HF6bC/Ku7WtG9sz4CHqEX7fJIjc0K3RWXY3x6B9luxaYazn3Q4U7Vqg3Lp2jftx2sJnbctRWkRERA7pjFLyK0BqNldQK24uS9GthGndfbhVHwY8REQUeKY3ctM8qqC1+pgKy3l4iQEPEREFnlc3cjdz6rzOzwtC/p9XdfBq4dR6DHiIiCiwvJicr3FuGLd0kqPS7jGn+9fZr8l2dkPQm/2ue36NLVRerDXGgIeIiAKrG8PMO10cs5NZiFtNcOhFoOf2sPxWc+20S1TWCZrcXJLCwoCHiIj6WieLYzZ7zK1kXSfPdZPfrWOmGPAQEZGn6ltH3FiTqdNt3cgX8aLLRfd4jf+vv671v5vUp5O1zdxaZ8vptrpEqWBEikS9TETOATjudz0otDYqpbJ+V8IEPxPkMePPBAMeIiIiCj12aREREVHoMeAhIiKi0GPAQ0RERKHHgIeIiIhCjwEPERERhR4DHiIiIgo9BjxEREQUegx4iIiIKPQY8BAREVHoMeAhIiKi0GPAQ0RERKHHgIeIiIhCjwEPERERhR4DHiIiIgo9BjxEREQUegx4iIiIKPQY8BAREVHoMeAhIiKi0GPAQ0RERKHHgIeIiIhCjwEPERERhR4DHiIiIgo9BjxEREQUegx4iIiIKPQY8BAREVHoMeAhIiKi0GPAQ0RERKHHgIeIiIhCjwEPERERhR4DHiIiIgo9BjxEREQUejG7J0WgACBSFxZZ/9f916uyQdx/EOvU6/sPYp24/863qf5pAcrl1wpb/9f916uyQdx/EOvU6/sPYp24/863UUrQAlt4iIiIKPQY8BAREVHoMeAhIiKi0GPAQ0RERKHHgIeIiIhCjwEPERERhR4DHiIiIgo9BjxEREQUeqKU8rsOgSMiH1dK/U+/6xFUvD7t8RrZ4/Vpj9fIHq9Pe7xGr8cWnuY+7ncFAo7Xpz1eI3u8Pu3xGtnj9WmP16gOAx4iIiIKPQY8REREFHoMeJpjn6c9Xp/2eI3s8fq0x2tkj9enPV6jOkxaJiIiotBjCw8RERGFHgOeFkTkt0XkURE5IiJ3i8iM33UKEhH5jyLyVPUafUFERv2uU5CIyPtF5AkRKYvIfr/rEyQicruIPC0iz4rIv/W7PkEjIn8hImdF5HG/6xJEIjIvIt8QkaPVz9jP+12nIBGRpIh8W0S+V70+/87vOgUFu7RaEJFhpdSV6v9/DsBOpdTP+lytwBCRdwC4RylVFJE/AACl1C/7XK3AEJEdAMoA/gzALyilHva5SoEgIlEAxwDcCuAkgIcAfFApddTXigWIiNwCYAnAXyqldvtdn6ARkTyAvFLquyIyBOA7AH6E76EKEREAaaXUkogMAPgnAD+vlHrA56r5ji08LVjBTlUaACPDOkqpu5VSxeqvDwCY87M+QaOUelIp9bTf9QigGwA8q5R6XilVAPDXAO7wuU6BopT6JoALftcjqJRSp5RS363+/yqAJwHM+lur4FAVS9VfB6o/vH+BAY8tEfkdEXkJwIcA/Ibf9QmwnwTwVb8rQT1hFsBLdb+fBG9W5JCILAC4HsCDPlclUEQkKiJHAJwF8A9KKV4f9HnAIyL/KCKPN/m5AwCUUr+mlJoH8GkAn/C3tt3X7vpUy/wagCIq16iv6FwfIvKGiGQAfB7Av2poke97SqmSUmofKi3vN4gIu0YBxPyugJ+UUj+oWfTTAL4C4Dc9rE7gtLs+IvJRAO8G8HbVh8lgBu8fes3LAObrfp+rPkakrZqb8nkAn1ZK/a3f9QkqpdQlEfkGgNsB9H0SfF+38NgRka11v94B4Cm/6hJEInI7gF8C8B6l1DW/60M94yEAW0Vkk4jEAfw4gC/5XCfqIdWk3D8H8KRS6j/7XZ+gEZGsNWpWRAZRGSDA+xc4SqslEfk8gO2ojLQ5DuBnlVL8JlolIs8CSAB4tfrQAxzF9hoR+VEA/xVAFsAlAEeUUrf5WqmAEJF3AvhjAFEAf6GU+h1/axQsIvIZAG8FMAngDIDfVEr9ua+VChAReTOAbwF4DJW/zwDwq0qpr/hXq+AQkT0APoXK5ysC4G+UUr/lb62CgQEPERERhR67tIiIiCj0GPAQERFR6DHgISIiotBjwENEREShx4CHiIiIQo8BDxEBqMyaXV1d+VEROSIiN1Yfv7d+xXcRWWhcyVtE/lhEXhaRSN1jHxWRc9V9HRWRf+FCHd8qIn/f6X6IqP/09UzLRFQhIodQmTX7jUqpNRGZBBDX3DYC4EdRWSPrLQC+Uff0XUqpT4jIFIAnRORLSqkzLlefiKgttvAQEQDkAZxXSq0BgFLqvFLqFc1t3wrgCQD/A8AHmxVQSp0F8ByAjfWPi8gDIrKr7vd7RWS/iNwgIv9PRB4RkftFZHvjPkXkkyLyC3W/P15dTBIi8mER+Xa1denPRCSqeS5EFFIMeIgIAO4GMC8ix0Tkv4vIWxqe/3Q1eDiCyrpy9T4I4DMAvgDgXdV1jl5HRDYD2Azg2Yan7gJwZ7VMHkBeKfUwKlPh36yUuh7AbwD4Xd0TEZEdAD4A4KbqAoolAB/S3Z6IwokBDxFBKbUE4E0APg7gHIC7qovDWj6klNpXDSDeaT1YXQ/rnQD+T3XF6gcB1C+h8YFqkPQZAD+jlLrQcOi/AfBj1f/fCeBz1f+PAPhsNVfojwDsgr63V8/loeqx345KsEVEfYw5PEQEAFBKlQDcC+BeEXkMwE8A+N9tNrsNwCiAxyprOiIFYAWAlVh8l1LqEzbHfFlEXq2u//MBANZ6bL8N4BtKqR+tdlPd22TzIl7/pS1Z/VcAfEop9Stt6k5EfYQtPEQEEdkuIlvrHtqHyqK57XwQwE8rpRaUUgsANgG4VURSBoe/C8AvARhRSj1afWwEgLVY70dbbPcigDdW6//G6rEB4OsAfqyaKA0RGReRjU33QER9gwEPEQFABsCnqsPHHwWwE8An7TaoBjW3A/iy9ZhSahnAPwH4YYNjfw7Aj6PSvWX5DwB+T0QeQeuW6M8DGBeRJwB8AsCxah2OAvh1AHdXz+UfUEnKJqI+xtXSiYiIKPTYwkNEREShx4CHiIiIQo8BDxEREYUeAx4iIiIKPQY8REREFHoMeIiIiCj0GPAQERFR6DHgISIiotD7//kQRHPqUXXIAAAAAElFTkSuQmCC\n"
      },
      "metadata": {
       "needs_background": "light"
@@ -299,10 +302,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 3 - Conclusions\n",
-    "The Shapley scores are estimated using KernelSHAP. The example here shows that the KernelSHAP method evaluates the importance of each segmentations/super pixels to the classification of geometric shapes and the results indicate that the model determines the shape by checking whether there is a (sharp) angle or not. For instance, the figure above shows that the sharp angle leads to negative scores against circle, and therefore the prediction is triangle. The interpretation agrees with the human visual preception of the chosen image."
+    "The Shapley scores are estimated using KernelSHAP. The example here shows that the KernelSHAP method evaluates the importance of each segmentations/super pixels to the classification of geometric shapes and the results indicate that the model determines the shape by checking whether there is a (sharp) angle or not. For instance, the figure above shows that the sharp angle leads to negative scores against circle, and therefore the prediction is triangle. The interpretation agrees with the human visual preception of the chosen image.\n"
    ]
   }
  ],

--- a/tutorials/kernelshap_mnist.ipynb
+++ b/tutorials/kernelshap_mnist.ipynb
@@ -2,7 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "<img width=\"150\" alt=\"Logo_ER10\" src=\"https://user-images.githubusercontent.com/3244249/151994514-b584b984-a148-4ade-80ee-0f88b0aefa45.png\">\n",
     "\n",
@@ -20,7 +24,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -34,7 +42,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 1 - Loading the model and the dataset\n",
     "Loads pretrained binary MNIST model and the image to be explained."
@@ -42,7 +54,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Load saved binary MNIST data."
    ]
@@ -50,7 +66,11 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# load dataset\n",
@@ -62,7 +82,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Load the pretrained binary MNIST model."
    ]
@@ -70,19 +94,12 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-02-11 15:34:31.613923: I tensorflow/compiler/jit/xla_cpu_device.cc:41] Not creating XLA devices, tf_xla_enable_xla_devices not set\n",
-      "2022-02-11 15:34:31.614552: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE4.1 SSE4.2 AVX AVX2 FMA\n",
-      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-02-11 15:34:31.616709: I tensorflow/core/common_runtime/process_util.cc:146] Creating new thread pool with default inter op setting: 2. Tune using inter_op_parallelism_threads for best performance.\n"
-     ]
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "# Load saved onnx model\n",
     "onnx_model_path = \"./models/mnist_model_tf.onnx\"\n",
@@ -93,7 +110,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Print class and image of a single instance in the test data for preview."
    ]
@@ -101,30 +122,12 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:AutoGraph could not transform <bound method BackendTFModule.__call__ of <tensorflow.python.eager.function.TfMethodTarget object at 0x7fdf8db18be0>> and will run it as-is.\n",
-      "Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.\n",
-      "Cause: module 'gast' has no attribute 'Index'\n",
-      "To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert\n",
-      "WARNING: AutoGraph could not transform <bound method BackendTFModule.__call__ of <tensorflow.python.eager.function.TfMethodTarget object at 0x7fdf8db18be0>> and will run it as-is.\n",
-      "Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.\n",
-      "Cause: module 'gast' has no attribute 'Index'\n",
-      "To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-02-11 15:34:34.090957: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:116] None of the MLIR optimization passes are enabled (registered 2)\n",
-      "2022-02-11 15:34:34.092894: I tensorflow/core/platform/profile_utils/cpu_utils.cc:112] CPU Frequency: 2304005000 Hz\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -134,9 +137,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7fdf8db00fa0>"
-      ]
+      "text/plain": "<matplotlib.image.AxesImage at 0x1e1b28c0eb0>"
      },
      "execution_count": 4,
      "metadata": {},
@@ -144,10 +145,8 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAANr0lEQVR4nO3db6gd9Z3H8c/HbPsk7QOzuYZo3aTbSFxZWLNoXLBE19KSCGL6wNUgksXCjRJNhIVdMWAjy4Lo1n1iSLil0uzStRSi2yBhG5GwWSEUb8Q/MXdb/xDT1EtiDFglSGP87oM7kZt4z8z1zMyZk3zfL7icc+Z7zpxvp34yc87vzPwcEQJw4buo6wYADAZhB5Ig7EAShB1IgrADSfzJIN/MNl/9Ay2LCM+0vNae3fZK27+x/ZbtB+usC0C73O84u+05kn4r6buSjkh6SdKaiDhY8hr27EDL2tizL5f0VkS8ExF/lPRzSbfWWB+AFtUJ+2WSfjft8ZFi2Vlsj9oetz1e470A1FTnC7qZDhW+cJgeEWOSxiQO44Eu1dmzH5F0+bTH35D0Xr12ALSlTthfknSF7W/a/qqkOyTtbKYtAE3r+zA+Ij61fZ+kX0maI+mpiHijsc4ANKrvobe+3ozP7EDrWvlRDYDzB2EHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSQx0ymYM3ty5c0vrjz/+eGl93bp1pfX9+/eX1m+77baetXfffbf0tWgWe3YgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIJZXC9wS5YsKa1PTEzUWv9FF5XvLzZs2NCztmXLllrvjZn1msW11o9qbB+S9JGk05I+jYhr6qwPQHua+AXd30bE8QbWA6BFfGYHkqgb9pC02/Z+26MzPcH2qO1x2+M13wtADXUP46+PiPdsXyLpedv/FxF7pz8hIsYkjUl8QQd0qdaePSLeK26PSXpW0vImmgLQvL7Dbnuu7a+fuS/pe5IONNUYgGbVOYxfIOlZ22fW858R8d+NdIUvZWRkpGdt+/btA+wEw6zvsEfEO5L+qsFeALSIoTcgCcIOJEHYgSQIO5AEYQeS4FLS54Gy00QlafXq1T1ry5d3+zunFStW9KxVnR776quvltb37t1bWsfZ2LMDSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBJcSvo8cPr06dL6Z599NqBOvqhqrLxOb1VTOt9+++2l9arppC9UvS4lzZ4dSIKwA0kQdiAJwg4kQdiBJAg7kARhB5JgnH0I7Nq1q7S+atWq0nqX4+wffPBBaf3jjz/uWVu0aFHT7Zxlzpw5ra5/WDHODiRH2IEkCDuQBGEHkiDsQBKEHUiCsANJcN34AbjhhhtK60uXLi2tV42jtznOvm3bttL67t27S+sffvhhz9pNN91U+tpNmzaV1qvce++9PWtbt26tte7zUeWe3fZTto/ZPjBt2Tzbz9t+s7i9uN02AdQ1m8P4n0paec6yByW9EBFXSHqheAxgiFWGPSL2SjpxzuJbJW0v7m+XtLrZtgA0rd/P7AsiYlKSImLS9iW9nmh7VNJon+8DoCGtf0EXEWOSxiROhAG61O/Q21HbCyWpuD3WXEsA2tBv2HdKWlvcXyvpl820A6Atleez235a0o2S5ks6KumHkv5L0i8k/Zmkw5Jui4hzv8SbaV0X5GH84sWLS+v79u0rrc+fP7+0Xufa7FXXXt+xY0dp/ZFHHimtnzx5srRepup89qrtNjIyUlr/5JNPetYefvjh0tc++eSTpfVTp06V1rvU63z2ys/sEbGmR+k7tToCMFD8XBZIgrADSRB2IAnCDiRB2IEkuJR0A5YsWVJan5iYqLX+qqG3PXv29Kzdcccdpa89fvx4Xz0Nwv33319af+KJJ0rrZdut6rTgK6+8srT+9ttvl9a7xKWkgeQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJLiV9HhgfHy+t33333T1rwzyOXmXnzp2l9TvvvLO0fu211zbZznmPPTuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJME4+wBUnY9e5brrrmuok/OLPeNp2Z+r2q51tvvmzZtL63fddVff6+4Ke3YgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIJx9gbcc889pfWqa5RjZrfccktpfdmyZaX1su1e9f9J1Tj7+ahyz277KdvHbB+Ytmyz7d/bfqX4u7ndNgHUNZvD+J9KWjnD8n+LiKuLv13NtgWgaZVhj4i9kk4MoBcALarzBd19tl8rDvMv7vUk26O2x22XX0gNQKv6DftWSd+SdLWkSUk/6vXEiBiLiGsi4po+3wtAA/oKe0QcjYjTEfGZpB9LWt5sWwCa1lfYbS+c9vD7kg70ei6A4VA5zm77aUk3Sppv+4ikH0q60fbVkkLSIUnr2mtx+FWNB2c2MjLSs3bVVVeVvvahhx5qup3Pvf/++6X1U6dOtfbeXakMe0SsmWHxT1roBUCL+LkskARhB5Ig7EAShB1IgrADSXCKK1q1adOmnrX169e3+t6HDh3qWVu7dm3paw8fPtxwN91jzw4kQdiBJAg7kARhB5Ig7EAShB1IgrADSTDOjlp27Sq/1ujSpUsH1MkXHTx4sGftxRdfHGAnw4E9O5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kwTh7A2yX1i+6qN6/qatWrer7tWNjY6X1Sy+9tO91S9X/27qcrppLfJ+NPTuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJME4ewO2bt1aWn/sscdqrf+5554rrdcZy257HLzN9W/btq21dV+IKvfsti+3vcf2hO03bG8sls+z/bztN4vbi9tvF0C/ZnMY/6mkf4iIv5D0N5LW275K0oOSXoiIKyS9UDwGMKQqwx4RkxHxcnH/I0kTki6TdKuk7cXTtkta3VKPABrwpT6z214saZmkX0taEBGT0tQ/CLYv6fGaUUmjNfsEUNOsw277a5J2SHogIv5QdfLHGRExJmmsWEf00ySA+mY19Gb7K5oK+s8i4pli8VHbC4v6QknH2mkRQBMcUb6z9dQufLukExHxwLTlj0v6ICIetf2gpHkR8Y8V67og9+yLFi0qre/bt6+0PjIyUlof5tNIq3o7evRoz9rExETpa0dHyz/9TU5OltZPnjxZWr9QRcSMh92zOYy/XtJdkl63/Uqx7CFJj0r6he0fSDos6bYG+gTQksqwR8SLknp9QP9Os+0AaAs/lwWSIOxAEoQdSIKwA0kQdiCJynH2Rt/sAh1nr7JixYrS+urVq0vrGzduLK0P8zj7hg0beta2bNnSdDtQ73F29uxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kATj7OeBlStXltbLzvuumrZ4586dpfWqKZ+rrlh08ODBnrXDhw+Xvhb9YZwdSI6wA0kQdiAJwg4kQdiBJAg7kARhB5JgnB24wDDODiRH2IEkCDuQBGEHkiDsQBKEHUiCsANJVIbd9uW299iesP2G7Y3F8s22f2/7leLv5vbbBdCvyh/V2F4oaWFEvGz765L2S1ot6e8kfRwR/zrrN+NHNUDrev2oZjbzs09Kmizuf2R7QtJlzbYHoG1f6jO77cWSlkn6dbHoPtuv2X7K9sU9XjNqe9z2eL1WAdQx69/G2/6apP+R9C8R8YztBZKOSwpJ/6ypQ/27K9bBYTzQsl6H8bMKu+2vSHpO0q8i4okZ6oslPRcRf1mxHsIOtKzvE2E8dfnQn0iamB704ou7M74v6UDdJgG0Zzbfxn9b0v9Kel3SmbmBH5K0RtLVmjqMPyRpXfFlXtm62LMDLat1GN8Uwg60j/PZgeQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSVRecLJhxyW9O+3x/GLZMBrW3oa1L4ne+tVkb4t6FQZ6PvsX3twej4hrOmugxLD2Nqx9SfTWr0H1xmE8kARhB5LoOuxjHb9/mWHtbVj7kuitXwPprdPP7AAGp+s9O4ABIexAEp2E3fZK27+x/ZbtB7vooRfbh2y/XkxD3en8dMUcesdsH5i2bJ7t522/WdzOOMdeR70NxTTeJdOMd7rtup7+fOCf2W3PkfRbSd+VdETSS5LWRMTBgTbSg+1Dkq6JiM5/gGF7haSPJf37mam1bD8m6UREPFr8Q3lxRPzTkPS2WV9yGu+Weus1zfjfq8Nt1+T05/3oYs++XNJbEfFORPxR0s8l3dpBH0MvIvZKOnHO4lslbS/ub9fUfywD16O3oRARkxHxcnH/I0lnphnvdNuV9DUQXYT9Mkm/m/b4iIZrvveQtNv2ftujXTczgwVnptkqbi/puJ9zVU7jPUjnTDM+NNuun+nP6+oi7DNNTTNM43/XR8RfS1olaX1xuIrZ2SrpW5qaA3BS0o+6bKaYZnyHpAci4g9d9jLdDH0NZLt1EfYjki6f9vgbkt7roI8ZRcR7xe0xSc9q6mPHMDl6Zgbd4vZYx/18LiKORsTpiPhM0o/V4bYrphnfIelnEfFMsbjzbTdTX4Pabl2E/SVJV9j+pu2vSrpD0s4O+vgC23OLL05ke66k72n4pqLeKWltcX+tpF922MtZhmUa717TjKvjbdf59OcRMfA/STdr6hv5tyVt6qKHHn39uaRXi783uu5N0tOaOqw7pakjoh9I+lNJL0h6s7idN0S9/YempvZ+TVPBWthRb9/W1EfD1yS9Uvzd3PW2K+lrINuNn8sCSfALOiAJwg4kQdiBJAg7kARhB5Ig7EAShB1I4v8B/55jyAhO1i4AAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
+      "text/plain": "<Figure size 432x288 with 1 Axes>",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAANrUlEQVR4nO3df4gU9xnH8c+jbf+x/UPrVcyPaluDQQqNxZhCg0lTWjQQvP6RRgnBksKZYKKBQisKqaEUQtKm/0SUCwm9ljalYNIeIq2pSG1ASs6QH+aubX6gVrmcMUIakRCjT//YMZx6853LzszOns/7BcfuzrM7+2SST2Z2vzvzNXcXgMvftKYbANAZhB0IgrADQRB2IAjCDgTxqU6+mZnx1T9QM3e3iZaX2rOb2XIz+7eZvWFmG8usC0C9rN1xdjObLuk/kr4j6aikFyStdvfhxGvYswM1q2PPvlTSG+7+lrt/KOkPklaWWB+AGpUJ+5WS/jvu8dFs2QXMrM/MhsxsqMR7ASip9i/o3L1fUr/EYTzQpDJ79mOSrh73+KpsGYAuVCbsL0i6xsy+ZGafkbRK0mA1bQGoWtuH8e7+kZndJ+mvkqZLesrdX6usMwCVanvora034zM7ULtaflQDYOog7EAQhB0IgrADQRB2IAjCDgRB2IEgCDsQBGEHgiDsQBCEHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIQdCIKwA0EQdiCIjk7ZjM6bMWNGsv7oo48m62vXrk3WDxw4kKzffvvtubXDhw8nX4tqsWcHgiDsQBCEHQiCsANBEHYgCMIOBEHYgSCYxfUyt2DBgmR9ZGSk1PqnTUvvL9avX59b27p1a6n3xsTyZnEt9aMaMzsk6X1JZyV95O5LyqwPQH2q+AXdt9z9RAXrAVAjPrMDQZQNu0vabWYHzKxvoieYWZ+ZDZnZUMn3AlBC2cP4G939mJl9QdJzZvYvd983/gnu3i+pX+ILOqBJpfbs7n4suz0u6VlJS6toCkD12g67mc0ws8+dvy/pu5IOVtUYgGqVOYyfI+lZMzu/nt+7+18q6QqfSE9PT25tYGCgg52gm7Uddnd/S9LXKuwFQI0YegOCIOxAEIQdCIKwA0EQdiAILiU9BaROE5Wk3t7e3NrSpc3+zmnZsmW5taLTY19++eVkfd++fck6LsSeHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeC4FLSU8DZs2eT9XPnznWok0sVjZWX6a1oSuc77rgjWS+aTvpylXcpafbsQBCEHQiCsANBEHYgCMIOBEHYgSAIOxAE4+xdYNeuXcn6ihUrkvUmx9nffffdZP3UqVO5tXnz5lXdzgWmT59e6/q7FePsQHCEHQiCsANBEHYgCMIOBEHYgSAIOxAE143vgJtuuilZX7hwYbJeNI5e5zj79u3bk/Xdu3cn6++9915u7ZZbbkm+dvPmzcl6kXvvvTe3tm3btlLrnooK9+xm9pSZHTezg+OWzTKz58zs9ex2Zr1tAihrMofxv5a0/KJlGyXtcfdrJO3JHgPoYoVhd/d9kk5etHilpIHs/oCk3mrbAlC1dj+zz3H30ez+25Lm5D3RzPok9bX5PgAqUvoLOnf31Aku7t4vqV/iRBigSe0OvY2Z2VxJym6PV9cSgDq0G/ZBSWuy+2sk/bmadgDUpfB8djN7WtLNkmZLGpP0U0l/kvRHSV+UdFjS99394i/xJlrXZXkYP3/+/GR9//79yfrs2bOT9TLXZi+69vqOHTuS9YceeihZP336dLKeUnQ+e9F26+npSdY/+OCD3NqDDz6YfO3jjz+erJ85cyZZb1Le+eyFn9ndfXVO6dulOgLQUfxcFgiCsANBEHYgCMIOBEHYgSC4lHQFFixYkKyPjIyUWn/R0NvevXtza6tWrUq+9sSJE2311An3339/sv7YY48l66ntVnRa8LXXXpusv/nmm8l6k7iUNBAcYQeCIOxAEIQdCIKwA0EQdiAIwg4EwaWkp4ChoaFk/e67786tdfM4epHBwcFk/c4770zWr7/++irbmfLYswNBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIyzd0DR+ehFbrjhhoo6mVrMJjwt+2NF27XMdt+yZUuyftddd7W97qawZweCIOxAEIQdCIKwA0EQdiAIwg4EQdiBIBhnr8A999yTrBddoxwTu+2225L1xYsXJ+up7V7076RonH0qKtyzm9lTZnbczA6OW7bFzI6Z2UvZ3631tgmgrMkcxv9a0vIJlv/K3a/L/nZV2xaAqhWG3d33STrZgV4A1KjMF3T3mdkr2WH+zLwnmVmfmQ2ZWfpCagBq1W7Yt0n6iqTrJI1K+mXeE929392XuPuSNt8LQAXaCru7j7n7WXc/J+kJSUurbQtA1doKu5nNHffwe5IO5j0XQHcoHGc3s6cl3SxptpkdlfRTSTeb2XWSXNIhSWvra7H7FY0HR9bT05NbW7RoUfK1mzZtqrqdj73zzjvJ+pkzZ2p776YUht3dV0+w+MkaegFQI34uCwRB2IEgCDsQBGEHgiDsQBCc4opabd68Obe2bt26Wt/70KFDubU1a9YkX3vkyJGKu2kee3YgCMIOBEHYgSAIOxAEYQeCIOxAEIQdCIJxdpSya1f6WqMLFy7sUCeXGh4ezq09//zzHeykO7BnB4Ig7EAQhB0IgrADQRB2IAjCDgRB2IEgGGevgJkl69Omlft/6ooVK9p+bX9/f7J+xRVXtL1uqfifrcnpqrnE94XYswNBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIyzV2Dbtm3J+iOPPFJq/Tt37kzWy4xl1z0OXuf6t2/fXtu6L0eFe3Yzu9rM9prZsJm9ZmYbsuWzzOw5M3s9u51Zf7sA2jWZw/iPJP3I3RdJ+oakdWa2SNJGSXvc/RpJe7LHALpUYdjdfdTdX8zuvy9pRNKVklZKGsieNiCpt6YeAVTgE31mN7P5khZL+qekOe4+mpXeljQn5zV9kvpK9AigApP+Nt7MPitph6QH3P1/42vu7pJ8ote5e7+7L3H3JaU6BVDKpMJuZp9WK+i/c/dnssVjZjY3q8+VdLyeFgFUwVo75cQTWudvDkg66e4PjFv+qKR33f1hM9soaZa7/7hgXek3m6LmzZuXrO/fvz9Z7+npSda7+TTSot7GxsZyayMjI8nX9vWlP/2Njo4m66dPn07WL1fuPuE515P5zP5NSXdJetXMXsqWbZL0sKQ/mtkPJR2W9P0K+gRQk8Kwu/vzkvKuzvDtatsBUBd+LgsEQdiBIAg7EARhB4Ig7EAQhePslb7ZZTrOXmTZsmXJem9vb7K+YcOGZL2bx9nXr1+fW9u6dWvV7UD54+zs2YEgCDsQBGEHgiDsQBCEHQiCsANBEHYgCMbZp4Dly5cn66nzvoumLR4cHEzWi6Z8Lpquenh4OLd25MiR5GvRHsbZgeAIOxAEYQeCIOxAEIQdCIKwA0EQdiAIxtmBywzj7EBwhB0IgrADQRB2IAjCDgRB2IEgCDsQRGHYzexqM9trZsNm9pqZbciWbzGzY2b2UvZ3a/3tAmhX4Y9qzGyupLnu/qKZfU7SAUm9as3HfsrdfzHpN+NHNUDt8n5UM5n52UcljWb33zezEUlXVtsegLp9os/sZjZf0mJJ/8wW3Wdmr5jZU2Y2M+c1fWY2ZGZD5VoFUMakfxtvZp+V9HdJP3f3Z8xsjqQTklzSz9Q61L+7YB0cxgM1yzuMn1TYzezTknZK+qu7PzZBfb6kne7+1YL1EHagZm2fCGOty4c+KWlkfNCzL+7O+56kg2WbBFCfyXwbf6Okf0h6VdL5uYE3SVot6Tq1DuMPSVqbfZmXWhd7dqBmpQ7jq0LYgfpxPjsQHGEHgiDsQBCEHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIQdCIKwA0EQdiCIwgtOVuyEpMPjHs/OlnWjbu2tW/uS6K1dVfY2L6/Q0fPZL3lzsyF3X9JYAwnd2lu39iXRW7s61RuH8UAQhB0Ioumw9zf8/ind2lu39iXRW7s60lujn9kBdE7Te3YAHULYgSAaCbuZLTezf5vZG2a2sYke8pjZITN7NZuGutH56bI59I6b2cFxy2aZ2XNm9np2O+Ecew311hXTeCemGW902zU9/XnHP7Ob2XRJ/5H0HUlHJb0gabW7D3e0kRxmdkjSEndv/AcYZrZM0ilJvzk/tZaZPSLppLs/nP2Pcqa7/6RLetuiTziNd0295U0z/gM1uO2qnP68HU3s2ZdKesPd33L3DyX9QdLKBvroeu6+T9LJixavlDSQ3R9Q6z+WjsvprSu4+6i7v5jdf1/S+WnGG912ib46oomwXynpv+MeH1V3zffuknab2QEz62u6mQnMGTfN1tuS5jTZzAQKp/HupIumGe+abdfO9Odl8QXdpW50969LWiFpXXa42pW89Rmsm8ZOt0n6ilpzAI5K+mWTzWTTjO+Q9IC7/298rcltN0FfHdluTYT9mKSrxz2+KlvWFdz9WHZ7XNKzan3s6CZj52fQzW6PN9zPx9x9zN3Puvs5SU+owW2XTTO+Q9Lv3P2ZbHHj226ivjq13ZoI+wuSrjGzL5nZZyStkjTYQB+XMLMZ2RcnMrMZkr6r7puKelDSmuz+Gkl/brCXC3TLNN5504yr4W3X+PTn7t7xP0m3qvWN/JuSNjfRQ05fX5b0cvb3WtO9SXparcO6M2p9t/FDSZ+XtEfS65L+JmlWF/X2W7Wm9n5FrWDNbai3G9U6RH9F0kvZ361Nb7tEXx3ZbvxcFgiCL+iAIAg7EARhB4Ig7EAQhB0IgrADQRB2IIj/A8nhboC3dEL1AAAAAElFTkSuQmCC\n"
      },
      "metadata": {
       "needs_background": "light"
@@ -171,7 +170,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 2 - Compute Shapley values and visualize the relevance attributions\n",
     "Approximate Shapley values using KernelSHAP and visualize the relevance attributions on the image. <br>\n",
@@ -185,18 +188,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
+      "text/plain": "  0%|          | 0/1 [00:00<?, ?it/s]",
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bb0c917d4d96462f8a48e69e1f00ba0e",
        "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
+       "version_minor": 0,
+       "model_id": "6063c70e03b84960bb8b72ca95d53062"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -204,7 +209,7 @@
    ],
    "source": [
     "# use KernelSHAP to explain the network's predictions\n",
-    "shap_values, segments_slic = dianna.explain_image(onnx_model_path, test_sample,\n",
+    "shap_values, segments_slic = dianna.explain_image(onnx_model_path, test_sample, labels=[1],\n",
     "                                                  method=\"KernelSHAP\", nsamples=1000,\n",
     "                                                  background=0, n_segments=200, sigma=0,\n",
     "                                                  axis_labels=('height','width','channels'))"
@@ -212,7 +217,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Define a function to fill each pixel with shap values based on the segmentation. <br>\n",
     "This function is used to make plots."
@@ -221,7 +230,11 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# fill each pixel with SHAP values \n",
@@ -234,22 +247,28 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Visualize Shapley scores on the images."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "execution_count": 7,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjwAAAD/CAYAAAD17AypAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAASAUlEQVR4nO3df7CldX0f8Pdn2dANkEjoLhaCw+KMJcFOy2/SiYOtdggyrK5OCBhicWzlR3Wwf9SWitPBNtYJzui0I4Ew005oRsWmYEMNJUQnyNgmILSCyhIi7a5iGN01EYN0+OF++8c9jNc95+Jz9txzz97vfb1mztyzn/N9nvM533OfO+99zvOcp1prAQDo2aZFNwAAMG8CDwDQPYEHAOiewAMAdE/gAQC6J/AAAN0TeACA7gk8wJqpqmOq6tNV9f2q2lNVv7ronmCRqurdVfVAVT1bVb+96H56tnnRDQAbyg1Jnkvy8iSnJvn9qnqotfbVhXYFi/PnSX49yS8l+ckF99K18k3LwFqoqiOT/GWSv9Vae2xU+50k32ytXbPQ5mDBqurXk5zQWnv7onvplY+0gLXyN5P84MWwM/JQklcvqB9gAxF4gLVyVJKnDqg9leSnFtALsMEIPMBaeTrJTx9Q++kkf7WAXoANRuAB1spjSTZX1auW1f5OEgcsA3Mn8ABrorX2/SS3J/nXVXVkVf1ikjcl+Z3FdgaLU1Wbq2pLksOSHFZVW6rKGdRzIPAAa+mfZOnU228n+WSSq5ySzgb3/iT/L8k1SX5tdP/9C+2oU05LBwC6Zw8PANA9gQcA6J7AAwB0T+ABALon8AAA3Tuoc/2ryqldzFVrrRbdwzS2bt3atm/fvug26NTu3buzb98+2wSMHMw24cuNYBVs3749D3zxi6u+3h/sH749H7bJ/0N6deZZZy26hanNa5vI/v3Dx27yIUavDmab8NsAAHRP4AEAuifwAADdE3gAgO4JPABA9wQeAKB7Ag8A0D2BBwDoni8ehEOYLxOEA/gyQQ6S3xwAoHsCDwDQPYEHAOiewAMAdE/gAQC6J/AAAN0TeACA7gk8AED3BB4AoHsCDwDQPZeWmMGRRx45Vvvwhz88VrviiismLv/ggw+O1S666KKJY/fs2TNld7AAL7wwbNxmf3rYGJ5/oQaN+4nNLiMzb/bwAADdE3gAgO4JPABA9wQeAKB7jhycwXHHHTdWe+c73zlW279//8TlzzjjjLHahRdeOHHsDTfcMGV3AMCL7OEBALon8AAA3RN4AIDuCTwAQPcEHgCge87SGmDbtm0T67fccssadwIL8Oijw8d+73vDxp199sH1AoeAXY8Ou1xEMnyTOMcmMXf28AAA3RN4AIDuCTwAQPcEHgCgew5aPsDVV189Vtu5c+fEsWfP4cDLc889d2J906bxbPrQQw9NHHvvvfeuak8AsN7ZwwMAdE/gAQC6J/AAAN0TeACA7gk8AED3nKV1gI9+9KNjtf3796/Z87/lLW8ZXN+zZ8/EsRdffPFY7cEHH5ytMfryxBPDxz722PCxr3nN9L2spueeGz728MPn1wfrzjeeGH65iPW0STz73PDX9dcOb3PsZPHs4QEAuifwAADdE3gAgO4JPABA9zbsQct33nnnxPqkSzjMy3e+852x2tNPPz1x7IknnjhWO+mkkyaOvf/++8dqhx122JTdAUA/7OEBALon8AAA3RN4AIDuCTwAQPcEHgCgexviLK3Xvva1Y7WTTz554thJl5GY9dISN91008T63XffPVZ76qmnJo593eteN1a79tprB/dw1VVXTazfeOONg9dBR+66a/jYXbuGj33jG6fvZTXdc8/wscceO3zsqadO2wnrzLw2iTe9cbGXa5hukxh+GYrTTl1/l6GwhwcA6J7AAwB0T+ABALon8AAA3evqoOXt27dPrN96661jta1bt878fHv27Bmr3XbbbWO1D3zgAxOXf+aZZ2Z6rssvv3zi2G3bto3Vrr/++oljt2zZMlb72Mc+NnHs888//1ItAsAhyx4eAKB7Ag8A0D2BBwDonsADAHRP4AEAutfVWVqbN09+ObOekfX5z39+Yv2SSy4Zq+3bt2+m51rJpLO0PvShD00c+5GPfGSsdsQRR0wcO+nsrTvuuGPi2Mcff/ylWmQ9+cQnho+9+ur59bHaVjhTc6Kf+7nhY2e8vAyHPpvEdJtEW4ebhD08AED3BB4AoHsCDwDQPYEHAOheVwctr4YHHnhgrPaOd7xj4th5HaA81EoHF1966aVjtbPOOmve7QDAIcseHgCgewIPANA9gQcA6J7AAwB0b0MctLxp0/Bcd84558yxk9VVVRPrk17vNHNw3XXXTay/7W1vG7wOFuD++4ePneaA+507p25lYZ54YvjY884bPnb37uFjp/lqW+bqvvsn/42cZJpN4s0720F0sxjz2iT+7+7hc3vS9kNjvuzhAQC6J/AAAN0TeACA7gk8AED3BB4AoHtdnaV15ZVXTqzv379/jTtZGzt27JhYP+2008ZqK83BpPpKZ2kBwHplDw8A0D2BBwDonsADAHRP4AEAutfVQcsrHcS7nmzbtm1i/ZRTThmrve9975v5+fbu3TtWe/7552deLwtw773Dx074ferCH//x8LFbtgwf63IR65JNYn6bxKFyuYhp2MMDAHRP4AEAuifwAADdE3gAgO4JPABA97o6S6sH11577cT6u971rpnWu3v37on1yy67bKz29a9/fabnAoBDjT08AED3BB4AoHsCDwDQPYEHAOieg5YX6M477xyrnXzyyXN5rkceeWRi/Qtf+MJcno8FOOGE4WM/+9n59bHabr55+NjPfW742Ouvn74X1pVeN4nfurkGj7VJ/JA9PABA9wQeAKB7Ag8A0D2BBwDonsADAHSvq7O0qiYfub5p0/Bc94Y3vGHw2JsnnD1y/PHHD15+Ul/79+8fvPw0duzYMZf1AsB6YA8PANA9gQcA6J7AAwB0T+ABALrX1UHLN95448T69VN8X/ZnPvOZsdo0BxLPetDxahy0fNNNN828DtahnTuHj/3EJ+bWxqrbsmX42AsvHD72zDOn74V1xSYx3SZx1plt+mbWEXt4AIDuCTwAQPcEHgCgewIPANA9gQcA6F5XZ2ndfvvtE+vvfe97x2rbtm2bdzsHZe/evRPru3btGqtdfvnlE8c++eSTq9oTAKx39vAAAN0TeACA7gk8AED3BB4AoHtdHbS8Z8+eifVLLrlkrLZzhe8cf8973rOaLU3tgx/84MT6DTfcsMadcEjYt2/42K1bh4+9447pe1lN3/3u8LHnnz987LHHTt0K68vefTV47Latwy+V8N8WvEn85XeHv65pNomXH9v35SKmYQ8PANA9gQcA6J7AAwB0T+ABALon8AAA3evqLK2V3HvvvYNqSXL33XeP1Va6hMOOHTvGandMOPvl5ptvnrh81fhR+Y888sjEsQDAwbOHBwDonsADAHRP4AEAuifwAADd2xAHLU/jrrvuGlSDNXHUUYvuYD6OPnrRHbBO9bpJ/MzRLgExb/bwAADdE3gAgO4JPABA9wQeAKB7Ag8A0D2BBwDonsADAHRP4AEAuifwAADdE3gAgO65tAQcyrZsWXQHcEj5yS0uwcDBsYcHAOiewAMAdE/gAQC6J/AAAN0TeACA7gk8AED3BB4AoHsCDwDQPYEHAOiewAMAdK9a8zXdMKuq2ptkz6L7oFsntta2LbqJadgmmLOptwmBBwDono+0AIDuCTwAQPcEHgCgewIPANA9gQcA6J7AAwB0T+ABALon8AAA3RN4AIDuCTwAQPcEHgCgewIPANA9gQcA6J7AAwB0T+ABALon8AAA3RN4AIDuCTwAQPcEHgCgewIPANA9gQcA6J7AAwB0T+ABALon8AAA3RN4AIDuCTwAQPcEHgCgewIPANA9gQcA6J7AAwB0T+ABALq3+aUerEpLkk3LYtGL94f+nNfYQ3H9h2JP6339h2JP1j/7MqM/Lcn+/T8c/OL9oT/nNfZQXP+h2NN6X/+h2JP1z75Ma5UV2MMDAHRP4AEAuifwAADdE3gAgO4JPABA9wQeAKB7Ag8A0D2BBwDoXrXWFt3DhlRVl7fWbl50HxuV+V8s879Y5n/xvAdrzx6exbl80Q1scOZ/scz/Ypn/xfMerDGBBwDonsADAHRP4Fkcn90ulvlfLPO/WOZ/8bwHa8xBywBA9+zhAQC6J/DMSVUdU1V/WFV/Nvr5MyuMO7+q/rSqvlZV1yyrf7iqHq2qh6vq01V19Jo134lVeA8uqqqvVtX+qjpz7Tpf31aaz2WPV1X9+9HjD1fV6UOX5cebcf7/Y1V9u6q+srZd9+Ng57+qXlFVf1RVu0Z/d96z9t13rrXmNodbkuuTXDO6f02S35gw5rAkjyd5ZZLDkzyU5JTRY+cl2Ty6/xuTlneb+3vw80lOTnJPkjMX/XrWw+2l5nPZmAuS/PckleQXktw3dFm3+c3/6LFzk5ye5CuLfi3r8Tbj7/9xSU4f3f+pJI/5/V/dmz088/OmJLeM7t+SZOeEMWcn+Vpr7f+01p5LcutoubTW7m6tvTAa9ydJTphvu12a9T3Y1Vr707VotCMrzucyb0ryn9qSP0lydFUdN3BZXtos85/W2r1J/mJNO+7LQc9/a+3J1tr/SpLW2l8l2ZXkZ9ey+d4JPPPz8tbak0ky+nnshDE/m+Qby/79RCb/gr8jS/8jYDqr+R4wzJD5XGmM92J2s8w/s1uV+a+q7UlOS3Lf6re4cW1edAPrWVV9NsnfmPDQtUNXMaH2I6fNVdW1SV5I8vHputsY1uI9YCpD5nOlMd6L2c0y/8xu5vmvqqOS3Jbkn7bWvreKvW14As8MWmv/YKXHqupbL+6mHO0u/vaEYU8kecWyf5+Q5M+XreOyJBcmeX0bfbDLj5r3e8DUhsznSmMOH7AsL22W+Wd2M81/Vf1ElsLOx1trt8+xzw3JR1rzc0eSy0b3L0vyexPGfDHJq6rqpKo6PMklo+VSVecn+RdJ3thae2YN+u3RTO8BB2XIfN6R5B+Ozlb5hSRPjT5y9F7Mbpb5Z3YHPf9VVUn+Q5JdrbWPrG3bG8Sij5ru9Zbkryf5XJI/G/08ZlQ/Psmdy8ZdkKWj8R9Pcu2y+tey9Dnvl0a3mxb9mtbbbRXegzdn6X9jzyb5VpI/WPRrWg+3SfOZ5MokV47uV5IbRo9/OcvOgFvpvXBbs/n/ZJInkzw/+t3/R4t+PevtdrDzn+Q1Wfpo6+Flf/cvWPTr6enmm5YBgO75SAsA6J7AAwB0T+ABALon8AAA3RN4AIDuCTxAkqVv9R5dpfnhqvpSVZ0zqt+z/GrxVbX9wKtpV9W/q6pvVtWmZbW3V9Xe0boeqap3rkKPf6+qPjPreoCNxzctA6mqv5ulb/U+vbX2bFVtzdI3Hw9ZdlOWvrPoG1m62vY9yx7+VGvt3VV1bJKvVtUdrbVvrW73AD+ePTxAkhyXZF9r7dkkaa3ta60NvdzA30/ylSQ3JnnrpAGttW9n6YvWTlxer6r7qurVy/59T1WdUVVnV9X/rKr/Pfp58oHrrKrrquqfLfv3V0YXXUxV/VpV3T/au/RbVXXYwNcCdErgAZLk7iSvqKrHquo3q+q1Bzz+8VF4+FKSOw947K1Z+obeTye5cHQ9oB9RVa9M8sosfYP4crcm+ZXRmOOSHN9aezDJo0nOba2dluRfJfm3Q19IVf18kouT/GJr7dQkP0hy6dDlgT4JPEBaa08nOSPJ5Un2JvlUVb192ZBLW2unjgLEBS8WR9cLuiDJf21LV3a+L8l5y5a7eBSSPpnkitbaXxzw1P85yUWj+7+S5HdH91+W5HdHxwp9NMmrM9zrR6/li6Pnfn2WwhawgTmGB0iStNZ+kKXjb+6pqi9n6YKrv/1jFjs/S+Hky0vXPswRSZ5J8vujxz/VWnv3SzznN6vqO1X1t7O0V+aK0UP/JskftdbePPqY6p4Ji7+QH/1P25bRz0pyS2vtX/6Y3oENxB4eIFV1clW9alnp1CR7Biz61iT/uLW2vbW2PclJSc6rqiOmePpbk/zzJC9rrX15VHtZkm+O7r99heV2Jzl91P/po+dOli4U+8ujA6VTVcdU1YkT1wBsGAIPkCRHJblldPr4w0lOSXLdSy0wCjW/lB/uzUlr7ftJvpBkxxTP/V+SXJKlj7dedH2SD1XV/0iy0gHHtyU5ZvSx1VVZukJ1WmuPJHl/krtHr+UPs3RQNrCBuVo6ANA9e3gAgO4JPABA9wQeAKB7Ag8A0D2BBwDonsADAHRP4AEAuifwAADd+/8GU626Xr1QRAAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 720x288 with 4 Axes>"
-      ]
+      "text/plain": "<Figure size 720x288 with 4 Axes>",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjwAAAD/CAYAAAD17AypAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAUWUlEQVR4nO3df5BV9XnH8c8DiyJQQdzFYsm4OFIMZioqKiZVUzT+phIbFasWZCpqZDCdqR0Up4Op1gZnNNNIQaZ/yMRGMYotA4xFU4HSxiCoaMBfaFkTorILCgJq2Oy3f9xDsuGexe/Zu+eee599v2bu7N3nPvec772Hs34895z7tRCCAAAAPOtT9AAAAADyRuABAADuEXgAAIB7BB4AAOAegQcAALhH4AEAAO4ReAAAgHsEHgBVY2ZDzexpM9trZi1m9pdFjwkokpnNMLP1Zva5mT1S9Hg8ayh6AAB6lXmSfi3pGEljJS03s40hhE2Fjgoozq8k3SPpQklHFDwW14xvWgZQDWY2UNJHkr4SQngrqf1Q0rYQwqxCBwcUzMzukTQihDC16LF4xUdaAKrljyW1Hwg7iY2STipoPAB6EQIPgGoZJGn3QbVdkv6ggLEA6GUIPACqZY+kIw+qHSnpkwLGAqCXIfAAqJa3JDWY2ahOtZMlccIygNwReABURQhhr6Qlkr5rZgPN7GuSLpf0w2JHBhTHzBrMrL+kvpL6mll/M+MK6hwQeABU07dVuvR2u6THJN3CJeno5e6S9KmkWZKuS+7fVeiInOKydAAA4B5HeAAAgHsEHgAA4B6BBwAAuEfgAQAA7hF4AACAe9261t/MuLQLuQohWNFjyKKxsTE0NzcXPQzUm8irZLe2tKitrY19Au7FXjje0rI18z7BlxsBPaC5uVnrX3yx6GGg3rS3R7WNGz8+54H0PPaJ/ATF/3feVF/HJ/a3x7228ePHZV42H2kBAAD3CDwAAMA9Ag8AAHCPwAMAANwj8AAAAPcIPAAAwD0CDwAAcI/AAwAA3OOLB4Ge0N4utbXF9TY25juWGB9/HN87ZEheo4izc2d879Ch8b379sX3DhgQ35tFQ+SfYKurL1mWVNolWiO/CLepsfgvx/vo4/j3+KghxY43yy5xdIZdYs/e+Pdg0MB83oN+DXHL7c4uwREeAADgHoEHAAC4R+ABAADuEXgAAIB7BB4AAOAegQcAALhH4AEAAO4ReAAAgHsEHgAA4B6BBwAAuMfUEhUYOHBgWe3+++8vq910002pz9+wYUNZ7corr0ztbWlpyTg6VFVDQ21MGRHrsMMKXf2y5fHfC3/ZpRm+Gz+LvKaLgKTSLlELU0bE6tev4AEsXx7devSll+YyhLymi6gVHOEBAADuEXgAAIB7BB4AAOAegQcAALjHScsVGD58eFntxhtvLKt1dHSkPv+0004rq1122WWpvfPmzcs4OgAAcABHeAAAgHsEHgAA4B6BBwAAuEfgAQAA7hF4AACAe1ylFaGpqSm1vmjRoiqPBOghWaZV2Lkzvnft2qi24SMuj19mLdi+Pb532LD8xoHcZJlWYcfO+KlRIncJXT6i/KrfWvbh9vj34JhhtTFlBUd4AACAewQeAADgHoEHAAC4R+ABAADucdLyQWbOnFlWmzRpUmrvGWec0ePrP+ecc1LrffqUZ9ONGzem9q5Zs6ZHxwQAQL3jCA8AAHCPwAMAANwj8AAAAPcIPAAAwD0CDwAAcI+rtA7y4IMPltU6Ojqqtv4rrrgiut7S0pLae/XVV5fVNmzYUNnA4Mv69fG9S5bE906bFtW27Efxizzt1PheZblCcezY+N7GxgyDQJ6C4qc0MMVPafDi+vjl5rBLSD9aFr/QU+N3itVr4l9XXrtEXtssK47wAAAA9wg8AADAPQIPAABwj8ADAADc67UnLa9YsSK1njaFQ1527NhRVtuzZ09q73HHHVdWGzlyZGrvunXrymp9+/bNODoAAPzgCA8AAHCPwAMAANwj8AAAAPcIPAAAwD0CDwAAcK9XXKV17rnnltVGjx6d2ps2jUSlU0ssWLAgtb5y5cqy2q5du1J7J0yYUFabPXt29BhuueWW1Pr8+fOjl4Ea99ln8b1ZtvvJJ0e3PrhsVFTfVVfFrz6TDz6I733kkfjeGTMyDwX5yDL1wKefxU9pkNMuoVHLyqcrSpXTTlELu0Se00VkwREeAADgHoEHAAC4R+ABAADuEXgAAIB7rk5abm5uTq0//vjjZbXGxsaK19fS0lJWe+qpp8pqd999d+rz9+3bV9G6pk+fntrb1NRUVps7d25qb//+/ctqDz30UGrv/v37DzVEAABqFkd4AACAewQeAADgHoEHAAC4R+ABAADuEXgAAIB7rq7SamhIfzmVXpG1evXq1PrkyZPLam1tbRWtqytpV2ndd999qb0PPPBAWW3AgAGpvWlXby1dujS195133jnUEFG0lCvuuvTGG/G9Z58d3fo3UyO/Qr69PX79Wf5MZdnXU/bfLs2cGd+LmnFE//gpDd58M34aigy7hDT1O1Ft+9vj198vw1QNee0St82sjekisuAIDwAAcI/AAwAA3CPwAAAA9wg8AADAPVcnLfeE9evXl9WmTZuW2pvXCcqxujq5+Nprry2rnX766XkPBwCAmsURHgAA4B6BBwAAuEfgAQAA7hF4AACAe73ipOU+feJz3ZlnnpnjSHqWWfo3c6a93izvwZw5c1Lr119/ffQyUIDnnovvffnl+N6pUzMP5Qt18a3oVXXiifG9L7wQ3zt+fPaxIBfPPhf/7cUvvRS/3Btiv1E8g34NxX9zcZZd4qcvxL+3Z40v/rVJHOEBAAC9AIEHAAC4R+ABAADuEXgAAIB7BB4AAOBeDVwq0XNuvvnm1HpHR0eVR1IdEydOTK2fcsopZbWu3oO0eldXaQEAUK84wgMAANwj8AAAAPcIPAAAwD0CDwAAcM/VSctdncRbT5qamlLrY8aMKavdeeedFa+vtbW1rLZ///6Kl4sCPPpofO8NN+Q3jiItXx7fO2xYfC/TRdQldon8dolamS4iC47wAAAA9wg8AADAPQIPAABwj8ADAADcI/AAAAD3XF2l5cHs2bNT67feemtFy926dWtqfcqUKWW19957r6J1AQBQazjCAwAA3CPwAAAA9wg8AADAPQIPAABwj5OWC7RixYqy2ujRo3NZ1+bNm1Pra9euzWV9OIS2tvjeDz6I7z3hhPjeLVviezNY/IRF9b37bvwy7xj0g/jmVaviex9+OL43J0Fx75d3rW3x70Od7RLSE0/E9WXYKX4w6I7o3tWro1u1YEF8bz3iCA8AAHCPwAMAANwj8AAAAPcIPAAAwD0CDwAAcM/VVVpm6Wf69+kTn+suvvji6N6FCxeW1Y499tjo56eNq6OjI/r5WUycODGX5QIAUA84wgMAANwj8AAAAPcIPAAAwD0CDwAAcM/VScvz589Prc+dOzd6GcuWLSurZTmRuNKTjnvipOUF3r8fvN41NubTO2xYfO9ZZ8X37tsX3drRMTCq745ZIX79jw6J7z3vvPjecePie3NiyvA+ONbUGP8+NGXaJeKnrPjqV+OXu2dv/HIHxf5NnzUreplDHo1u1YQJ8b2nj/P975EjPAAAwD0CDwAAcI/AAwAA3CPwAAAA9wg8AADAPVdXaS1ZsiS1fvvtt5fVmpqa8h5Ot7S2tqbWX3/99bLa9OnTU3vff//9Hh0TAAD1jiM8AADAPQIPAABwj8ADAADcI/AAAAD3XJ203NLSklqfPHlyWW3SpEmpvbfddltPDimze++9N7U+b968Ko8EdSfL1BLLl8f3DhgQ3XrCCZGNu3fHr//88+N7r7suvrcWtLXF9bW35zsOp44ZFj9VwrJlGaaLGJhhCobInWLX7vj1Z9klrr+uvqaLaG2Lex+6s0twhAcAALhH4AEAAO4ReAAAgHsEHgAA4B6BBwAAuOfqKq2urFmzJqomSStXriyrdTWFw8SJE8tqS5cuLastXLgw9flm5Wejb968ObUXAAB0H0d4AACAewQeAADgHoEHAAC4R+ABAADu9YqTlrN45plnompAXTvxxFwWe/q42K+xPzJ+oUdm6K03jY1xfQ38qc7bl0/MaQqGceOi2gYrfv2DHe8STY1x70N3dgmO8AAAAPcIPAAAwD0CDwAAcI/AAwAA3CPwAAAA9wg8AADAPQIPAABwj8ADAADcI/AAAAD3CDwAAMA9vq8cAHrSvn3xvbt3x/Xt39+9sQA1YM9ei+795JO4vu7sEhzhAQAA7hF4AACAewQeAADgHoEHAAC4R+ABAADuEXgAAIB7BB4AAOAegQcAALhH4AEAAO4ReAAAgHsWQih6DEDdM7NWSS1FjwNuHRdCaCp6EFmwTyBnmfcJAg8AAHCPj7QAAIB7BB4AAOAegQcAALhH4AEAAO4ReAAAgHsEHgAA4B6BBwAAuEfgAQAA7hF4AACAewQeAADgHoEHAAC4R+ABAADuEXgAAIB7BB4AAOAegQcAALhH4AEAAO4ReAAAgHsEHgAA4B6BBwAAuEfgAQAA7hF4AACAewQeAADgHoEHAAC4R+ABAADuEXgAAIB7BB4AAOAegQcAALhH4AEAAO4ReAAAgHsEHgAA4B6BBwAAuNdwqAfNFCSpT6dYdOB+7M+8emtx+bU4pnpffi2OieVX/pzkT4vU0fG75gP3Y3/m1VuLy6/FMdX78mtxTCy/8ueEYOoCR3gAAIB7BB4AAOAegQcAALhH4AEAAO4ReAAAgHsEHgAA4B6BBwAAuEfgAQAA7lkIoegxuGVm00MIC4seB0rYHrWDbVFb2B61g22RH47w5Gt60QPA72F71A62RW1he9QOtkVOCDwAAMA9Ag8AAHCPwJMvPoetLWyP2sG2qC1sj9rBtsgJJy0DAAD3OMIDAADcI/BUyMyGmtmzZvZ28vOoLvqmJD1vm9mUpDbAzJab2RtmtsnM/qm6o/enku2R1O81s1+Y2Z7qjdoXM7vIzN40sy1mNivl8cPNbHHy+M/MrLnTY3ck9TfN7MKqDtyh7m4LMzvazJ43sz1m9lDVB+5UBdvjG2a2wcxeS35OqPrgPQghcKvgJmmupFnJ/VmSvpfSM1TSu8nPo5L7R0kaIOnPkp7DJP23pIuLfk31fKtkeySPjZc0XNKeol9LPd4k9ZX0jqTjk3/TGyWNOajn25IWJPcnS1qc3B+T9B8uaWSynL5Fv6Z6vVW4LQZK+lNJN0t6qOjX4uFW4fY4RdKxyf2vSNpW9OupxxtHeCp3uaRFyf1Fkial9Fwo6dkQws4QwkeSnpV0UQhhXwjheUkKIfxa0kuSRuQ/ZNe6vT0kKYTwQgjh/WoM1KkzJG0JIbyb/Jt+XKVt0lnnbfSkpPPMzJL64yGEz0MI/ydpS7I8dE+3t0UIYW8IYa2kz6o3XPcq2R4vhxB+ldQ3STrCzA6vyqgdIfBU7phO/4H8QNIxKT1/JOkXnX7/ZVL7LTMbImmipJ/kMMbepEe2B7ot5r39bU8IoV3SLklHRz4X8SrZFuh5PbU9/kLSSyGEz3Map1sNRQ+gHpjZc5L+MOWh2Z1/CSEEM8t82ZuZNUh6TNI/hxDe7d4oe4+8twcA1CIzO0nS9yRdUPRY6hGBJ0II4fyuHjOzD81seAjhfTMbLml7Sts2SV/v9PsISas6/b5Q0tshhO9XPlr/qrA90H3bJH2p0+8jklpazy+TsD9Y0o7I5yJeJdsCPa+i7WFmIyQ9LemvQgjv5D9cf/hIq3JLJR24ymeKpP9I6flPSReY2VHJVUMXJDWZ2T0q/aP+Tv5D7RUq2h6o2IuSRpnZSDM7TKUTL5ce1NN5G31L0n+F0tmYSyVNTq5UGSlplKR1VRq3R5VsC/S8bm+P5JSH5SpdkPE/1RqwO0WfNV3vN5U+X/2JpLclPSdpaFIfJ+lfO/VNU+kkzC2SbkhqIyQFSa9LeiW5/XXRr6meb5Vsj6Q+V6XP1juSn3OKfk31dpN0iaS3VLoiZXZS+66kP0/u95f04+S9Xyfp+E7PnZ08701xxWLR22KrpJ2S9iT7wphqj9/brbvbQ9JdkvZ2+u/EK5KGFf166u3GNy0DAAD3+EgLAAC4R+ABAADuEXgAAIB7BB4AAOAegQcAALhH4AEgSTKz2Wa2ycxeNbNXzOzMpL7KzMZ16ms2s58f9Nzvm9k2M+vTqTbVzFqTZW02sxt7YIxfN7NllS4HQO/DNy0DkJmdJekySaeGED43s0aVZnSOeW4fSd9UaQ6gcyU93+nhxSGEGWY2TNImM1saQviwh4cPAF+IIzwAJGm4pLaQTEgYQmgLv5ud+Yt8XaUZnOdLuiatIYSwXaUvWzuuc93MXkjmBzrw+yozG2dmZ5jZT83sZTP7XzMbffAyzWyOmf1tp99/bmbNyf3rzGxdcnTpYTPrG/laADhF4AEgSSslfcnM3jKzfzGzcw96/N+S8PCKpBUHPXaNSpPfPi3pUjPrd/DCzex4Scer9A2ynS2WdFXSM1zS8BDCeklvSDo7hHCKpL+X9I+xL8TMvizpaklfCyGMlfQbSdfGPh+ATwQeAAoh7JF0mqTpklolLTazqZ1arg0hjE0CxCUHismcQJdI+vcQwm5JP5N0YafnXZ2EpMck3RRC2HnQqp9Qac4gqRR8nkzuD5b04+RcoQclnaR45yWv5cVk3eepFLYA9GKcwwNAkhRC+I1Ks8avMrPXVJrE8JEveNqFkoZIes3MJGmApE8lHTixeHEIYcYh1rnNzHaY2Z+odFTm5uShf5D0fAjhm8nHVKtSnt6u3/+ftv7JT5O0KIRwxxeMHUAvwhEeADKz0WY2qlNprKSWiKdeo9KEt80hhGZJIyV9w8wGZFj9Ykl/J2lwCOHVpDZY0rbk/tQunrdV0qnJ+E9N1i2VJo/9VnKitMxsqJkdl7oEAL0GgQeAJA2StCi5fPxVSWMkzTnUE5JQc5Gk5QdqIYS9ktZKmphh3U9KmqzSx1sHzJV0n5m9rK6PRD8laaiZbZI0Q6VZqBVC2KzS7NIrk9fyrEonZQPoxZgtHQAAuMcRHgAA4B6BBwAAuEfgAQAA7hF4AACAewQeAADgHoEHAAC4R+ABAADuEXgAAIB7/w8WRBPelzkGGgAAAABJRU5ErkJggg==\n"
      },
      "metadata": {
       "needs_background": "light"
@@ -283,10 +302,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 3 - Conclusions\n",
-    "The Shapley scores are estimated using KernelSHAP for models used to categorize the binary MNIST. The example here shows that the KernelSHAP method evaluates the importance of each segmentation/super pixel to the classification and the results are reasonable compared to the human visual preception of the chosen testing hand-written digit image."
+    "The Shapley scores are estimated using KernelSHAP for models used to categorize the binary MNIST. The example here shows that the KernelSHAP method evaluates the importance of each segmentation/super pixel to the classification and the results are reasonable compared to the human visual preception of the chosen testing hand-written digit image.\n"
    ]
   }
  ],

--- a/tutorials/lime_text.ipynb
+++ b/tutorials/lime_text.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "african-verse",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "<img width=\"150\" alt=\"Logo_ER10\" src=\"https://user-images.githubusercontent.com/3244249/151994514-b584b984-a148-4ade-80ee-0f88b0aefa45.png\">\n",
     "\n",
@@ -16,7 +20,11 @@
   {
    "cell_type": "markdown",
    "id": "a5cf6f82-c1c7-4814-ae0f-5a1c0b8578f6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 1. Imports and paths"
    ]
@@ -25,7 +33,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "34b556d8-5337-44dc-8efe-14d1dff6f011",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -45,7 +57,11 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "c616916c-78ef-48d0-a744-b25b37b62a3f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "model_path = 'models/movie_review_model.onnx'\n",
@@ -56,7 +72,11 @@
   {
    "cell_type": "markdown",
    "id": "bad4f5b1-6097-4ef3-98c4-78432ad640b0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 2. Loading the model\n",
     "\n",
@@ -66,12 +86,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "486540bd-2676-4dfa-bbe8-ee8aa289acd3",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✔ Download and installation successful\n",
+      "You can now load the package via spacy.load('en_core_web_sm')\n"
+     ]
+    }
+   ],
    "source": [
     "# ensure the tokenizer for english is available\n",
     "spacy.cli.download('en_core_web_sm')"
@@ -81,7 +113,11 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "555842c5-3f82-4f63-93bb-696645d4b447",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "class MovieReviewsModelRunner:\n",
@@ -124,7 +160,11 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "443e8a99-6fa3-4a73-9311-2fbe0251c2b1",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# define model runner. max_filter_size is a property of the model\n",
@@ -134,7 +174,11 @@
   {
    "cell_type": "markdown",
    "id": "02ccb569-a2e9-41b3-a732-f6c31a929a90",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 3. Applying LIME with DIANNA\n",
     "The simplest way to run DIANNA on text data is with `dianna.explain_text`. The arguments are:\n",
@@ -150,7 +194,11 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "7fc6ebcb-2328-4c06-ae67-c5590032eb69",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "review = \"A delectable and intriguing thriller filled with surprises\""
@@ -160,20 +208,15 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "7c0bfd7d-df1d-4981-b714-496bc16b9347",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "[('intriguing', 3, 0.18379392986356602),\n",
-       " ('thriller', 4, 0.07241839614499643),\n",
-       " ('delectable', 1, 0.06677609981740236),\n",
-       " ('and', 2, 0.01734695021775524),\n",
-       " ('with', 6, 0.013909200028387934),\n",
-       " ('filled', 5, -0.013094230898609081),\n",
-       " ('surprises', 7, 0.005932602337045452),\n",
-       " ('A', 0, 0.003498162477570695)]"
-      ]
+      "text/plain": "[('intriguing', 3, 0.17991817503188104),\n ('thriller', 4, 0.07272165900066206),\n ('delectable', 1, 0.06385917112822656),\n ('and', 2, 0.018768302468074188),\n ('with', 6, 0.014625215393226832),\n ('filled', 5, -0.013270820821030292),\n ('A', 0, 0.005009499107843555),\n ('surprises', 7, 0.004948493361510772)]"
      },
      "execution_count": 7,
      "metadata": {},
@@ -181,15 +224,20 @@
     }
    ],
    "source": [
-    "# An explanation is returned for each label, but we ask for just one label so the output is a list of length one.\n",
-    "explanation_relevance = dianna.explain_text(model_runner, review, model_runner.tokenizer, 'LIME', label=labels.index('positive'))[0]\n",
+    "# We're getting the explanation for the 'positive' class only, but dianna supports explaining for multiple labels in one\n",
+    "# go. It therefore always outputs a list of saliency maps. We want the first and only saliency map from this list here.\n",
+    "explanation_relevance = dianna.explain_text(model_runner, review, model_runner.tokenizer, 'LIME', labels=[labels.index('positive')])[0]\n",
     "explanation_relevance"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "7e177746-3654-4518-9c1c-b7047f922273",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### 4. Visualization\n",
     "DIANNA includes a visualization package, capable of highlighting the relevance of each word in the text for a chosen class. The visualization is in HTML format.\n",
@@ -200,16 +248,16 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "0136005d-a22f-43a0-80da-4ec1f283f870",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<html><body><span style=\"background:rgba(255, 0, 0, 0.02)\">A</span> <span style=\"background:rgba(255, 0, 0, 0.29)\">delectable</span> <span style=\"background:rgba(255, 0, 0, 0.08)\">and</span> <span style=\"background:rgba(255, 0, 0, 0.80)\">intriguing</span> <span style=\"background:rgba(255, 0, 0, 0.32)\">thriller</span> <span style=\"background:rgba(0, 0, 255, 0.056995)\">filled</span> <span style=\"background:rgba(255, 0, 0, 0.06)\">with</span> <span style=\"background:rgba(255, 0, 0, 0.03)\">surprises</span></body></html>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
+      "text/plain": "<IPython.core.display.HTML object>",
+      "text/html": "<html><body><span style=\"background:rgba(255, 0, 0, 0.02)\">A</span> <span style=\"background:rgba(255, 0, 0, 0.28)\">delectable</span> <span style=\"background:rgba(255, 0, 0, 0.08)\">and</span> <span style=\"background:rgba(255, 0, 0, 0.80)\">intriguing</span> <span style=\"background:rgba(255, 0, 0, 0.32)\">thriller</span> <span style=\"background:rgba(0, 0, 255, 0.059008)\">filled</span> <span style=\"background:rgba(255, 0, 0, 0.07)\">with</span> <span style=\"background:rgba(255, 0, 0, 0.02)\">surprises</span></body></html>"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -222,9 +270,13 @@
   {
    "cell_type": "markdown",
    "id": "dc3325a0-c091-4212-938d-7ef771304b22",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
-    "The most important word for this review being classified as positive is \"intriguing\", followed by \"delectable\" and \"thriller\"."
+    "The most important word for this review being classified as positive is \"intriguing\", followed by \"delectable\" and \"thriller\".\n"
    ]
   }
  ],


### PR DESCRIPTION
I changed the signatures of all explain_image or explain_text definitions. I changed the label kwarg into a positional argument. No need for error checking because it is now automatically a TypeError to call any of those methods without a labels argument.