### PR TITLE
Unpin prospector

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,8 +62,8 @@ install_requires =
 [options.extras_require]
 dev =
     bump2version
-    prospector[with_pyroma]==1.7.7  # last version that works, see https://github.com/PyCQA/prospector/issues/545
-    pylint==2.15.6
+    prospector[with_pyroma]
+    pylint
     isort
     pytest
     pytest-cov


### PR DESCRIPTION
Version 1.8.4 should have fixed the issues previously mentioned in #423. See https://github.com/PyCQA/prospector/milestone/7?closed=1. Also relevant to the discussion in https://github.com/NLeSC/python-template/issues/327