### PR TITLE
refactor rise and fix linter issues (refs 447)

### DIFF
--- a/dianna/methods/lime.py
+++ b/dianna/methods/lime.py
@@ -7,7 +7,7 @@ from dianna import utils
 class LIMEText:
     """Wrapper around the LIME explainer implemented by Marco Tulio Correia Ribeiro (https://github.com/marcotcr/lime)."""
 
-    def __init__(self,
+    def __init__(self,  # pylint: disable=too-many-arguments
                  kernel_width=25,
                  kernel=None,
                  verbose=False,
@@ -110,7 +110,7 @@ class LIMEText:
 class LIMEImage:
     """Wrapper around the LIME explainer implemented by Marco Tulio Correia Ribeiro (https://github.com/marcotcr/lime)."""
 
-    def __init__(self,
+    def __init__(self,  # pylint: disable=too-many-arguments
                  kernel_width=25,
                  kernel=None,
                  verbose=False,

--- a/dianna/methods/lime.py
+++ b/dianna/methods/lime.py
@@ -1,6 +1,6 @@
 import numpy as np
-from lime.lime_image import LimeImageExplainer
-from lime.lime_text import LimeTextExplainer
+from lime.lime_image import LimeImageExplainer  # pylint: disable=old-import-error
+from lime.lime_text import LimeTextExplainer  # pylint: disable=old-import-error
 from dianna import utils
 
 

--- a/dianna/utils/__init__.py
+++ b/dianna/utils/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa: F401
+"""DIANNA utilities."""
 from .misc import get_function
 from .misc import get_kwargs_applicable_to_function
 from .misc import locate_channels_axis

--- a/dianna/visualization/__init__.py
+++ b/dianna/visualization/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa: F401
+"""Tools for visualization of model explanations."""
 from .image import plot_image
 from .text import highlight_text

--- a/tests/test_common_usage.py
+++ b/tests/test_common_usage.py
@@ -10,6 +10,7 @@ labels = [0, 1]
 
 
 def test_common_RISE_pipeline():  # noqa: N802 ignore case
+    """No errors thrown while creating a relevance map and visualizing it."""
     heatmap = dianna.explain_image(run_model, input_data, "RISE",  labels, axis_labels=axis_labels)[0]
     dianna.visualization.plot_image(heatmap, show_plot=False)
     dianna.visualization.plot_image(heatmap, original_data=input_data[0], show_plot=False)


### PR DESCRIPTION
This solves all linter issues currently in main.

Most issues were solved by adding disabling comments. Wherever possible, I tried adapting the code instead to satisfy to linter rules. For instance, I did some refactoring to get the number of variables in scope down in `rise.py`.