### PR TITLE
Cache python install in github actions

### DIFF
--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
     

--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -16,13 +16,18 @@ runs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ inputs.python-version }}
-        cache: 'pip'
-        cache-dependency-path: setup.cfg
+    
+    - uses: actions/cache@v3
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.cfg') }}
+    
     - name: Python info
       shell: bash {0}
       run: |
         which python3
         python3 --version
+    
     - name: Upgrade pip and install dependencies
       shell: bash {0}
       run: |

--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -32,4 +32,4 @@ runs:
       shell: bash {0}
       run: |
         python3 -m pip install --upgrade pip setuptools wheel
-        python3 -m pip install .[${{ inputs.extras-require }}]
+        python3 -m pip install -e .[${{ inputs.extras-require }}]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,14 +5,14 @@ on:
   push:
     branches:
     - main
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
   pull_request:
     branches:
     - main
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - ready_for_review
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
     - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   pull_request:
     branches:
     - main

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,14 +5,14 @@ on:
   push:
     branches:
     - main
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
   pull_request:
     branches:
     - main
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - ready_for_review
 
 jobs:
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
     - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   pull_request:
     branches:
     - main

--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
     - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   pull_request:
     branches:
     - main

--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -5,14 +5,14 @@ on:
   push:
     branches:
     - main
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
   pull_request:
     branches:
     - main
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - ready_for_review
 
 jobs:
   verify_main:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,14 +5,14 @@ on:
   push:
     branches:
     - main
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
   pull_request:
     branches:
     - main
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - ready_for_review
 
 jobs:
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
     - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   pull_request:
     branches:
     - main

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -5,14 +5,14 @@ on:
   push:
     branches:
     - main
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
   pull_request:
     branches:
     - main
+    types:
+    - opened
+    -  reopened
+    - synchronize
+    - ready_for_review
 
 jobs:
 

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
     - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   pull_request:
     branches:
     - main

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -5,14 +5,14 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    branches:
+    - main
     types:
       - opened
       - reopened
       - synchronize
       - ready_for_review
-  pull_request:
-    branches:
-    - main
 
 jobs:
 

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
     - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   pull_request:
     branches:
     - main

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,7 +6,11 @@ on:
     branches:
     - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
     - main
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,13 +6,13 @@ on:
     branches:
     - main
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
     branches:
     - main
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - ready_for_review
 
 jobs:
 


### PR DESCRIPTION
This PR caches the python environment. This will significantly reduce the time it will take to run the tests on github actions.

All steps should run roughly 2-3x faster now. I also made it so that the tests only run when the PR is ready for review. This helps save cpu cycles, and saving cpu cycles is good for the environment 🌱


Closes #475