### PR TITLE
Fix conflict with number of lines after import between yapf and ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,5 +93,5 @@ line-length = 120
 [tool.ruff.isort]
 known-first-party = ["dianna"]
 force-single-line = true
-lines-after-imports = 2
+lines-after-imports = 1
 no-lines-before = ["future","standard-library","third-party","first-party","local-folder"]


### PR DESCRIPTION
I noticed yapf and ruff have an incompatibility in the number of blank lines after imports. This PR configures yapf to add 2 lines after the imports so that it is compatible with ruff (and our previous isort config).