### PR TITLE
add building for PRs in draft

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
     types:
     - opened
     - reopened
+    - edited
     - synchronize
     - ready_for_review
 


### PR DESCRIPTION
I think this should turn on the build workflow for every commit to a PR whether it's in draft or not.
I know it's not the most eco-friendly but this way we get feedback much earlier which will help code development and prevent asking reviewers to review PRs with obvious errors.

_I see @stefsmeets is working to create the complete opposite of what I'm doing here. We should discuss this first :-)_
