### PR TITLE
Fix conflict with number of lines after imports between yapf and ruff

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -99,3 +99,6 @@ text =
 
 [options.packages.find]
 include = dianna, dianna.*
+
+[yapf]
+blank_lines_between_top_level_imports_and_variables = 2


### PR DESCRIPTION
I noticed yapf and ruff have an incompatibility in the number of blank lines after imports. This PR configures yapf to add 2 lines after the imports so that it is compatible with ruff (and our previous isort config).