### PR TITLE
Drop support for python 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ command_line = "-m pytest"
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py37,py38,py39
+envlist = py38,py39,310
 skip_missing_interpreters = true
 
 [testenv]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -30,7 +29,7 @@ version = 0.9.0
 license = Apache License 2.0
 
 [options]
-python_requires = >=3.7,<3.11
+python_requires = >=3.8,<3.11
 zip_safe = False
 include_package_data = True
 packages = find_namespace:
@@ -49,7 +48,7 @@ install_requires =
     tqdm
     xarray
     # tf and tfprob are required but not declared by onnx_tf
-    tensorflow >= 2.11
+    tensorflow >= 2.12
     tensorflow_probability
     # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
     importlib_resources;python_version<'3.10'


### PR DESCRIPTION
This PR drops support for Python 3.7.

Closes #587 

Cool new python features we get from supporting [3.8](https://www.python.org/downloads/release/python-380/) and up:

- Walrus operator
- `=` specifier in f-strings
