### PR TITLE
Avoid pip install in workflow if cache is hit

### DIFF
--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -18,6 +18,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - uses: actions/cache@v3
+      id: cache-python-env
       with:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('setup.cfg') }}
@@ -29,19 +30,21 @@ runs:
         python3 --version
 
     - name: Upgrade pip
+      if: steps.cache-python-env.outputs.cache-hit != true
       shell: bash {0}
       run: |
         python3 -m pip install --upgrade pip setuptools wheel
 
     # only necessary on linux to avoid bloated installs
     - name: Install tensorflow/pytorch cpu version
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && steps.cache-python-env.outputs.cache-hit != true
       shell: bash {0}
       run: |
         python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
         python3 -m pip install tensorflow-cpu
 
     - name: Upgrade pip
+      if: steps.cache-python-env.outputs.cache-hit != true
       shell: bash {0}
       run: |
         python3 -m pip install -e .[${{ inputs.extras-require }}]

--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -7,8 +7,8 @@ inputs:
     default: "3.9"
   extras-require:
     required: false
-    description: "The extras dependencies packages to be installed, for instance 'dev' or 'dev,publishing,notebooks'."
-    default: "dev"
+    description: "The extras dependencies packages to be installed, for instance 'docs' or 'publishing,notebooks'."
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -21,7 +21,7 @@ runs:
       id: cache-python-env
       with:
         path: ${{ env.pythonLocation }}
-        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.cfg') }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.cfg') }}-${{ inputs.extras-require }}
 
     - name: Python info
       shell: bash {0}
@@ -43,8 +43,14 @@ runs:
         python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
         python3 -m pip install tensorflow-cpu
 
-    - name: Upgrade pip
+    - name: Install DIANNA
       if: steps.cache-python-env.outputs.cache-hit != 'true'
+      shell: bash {0}
+      run: |
+        python3 -m pip install -e .[dev]
+
+    - name: Install DIANNA extras
+      if: ${{ inputs.extras-require }} != ""
       shell: bash {0}
       run: |
         python3 -m pip install -e .[${{ inputs.extras-require }}]

--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -21,7 +21,7 @@ runs:
       id: cache-python-env
       with:
         path: ${{ env.pythonLocation }}
-        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.cfg') }}-${{ inputs.extras-require }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.cfg') }}
 
     - name: Python info
       shell: bash {0}

--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -50,7 +50,7 @@ runs:
         python3 -m pip install -e .[dev]
 
     - name: Install DIANNA extras
-      if: ${{ inputs.extras-require }} != ""
+      if: ${{ inputs.extras-require != "" }}
       shell: bash {0}
       run: |
         python3 -m pip install -e .[${{ inputs.extras-require }}]

--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -30,21 +30,21 @@ runs:
         python3 --version
 
     - name: Upgrade pip
-      if: steps.cache-python-env.outputs.cache-hit != true
+      if: steps.cache-python-env.outputs.cache-hit != 'true'
       shell: bash {0}
       run: |
         python3 -m pip install --upgrade pip setuptools wheel
 
     # only necessary on linux to avoid bloated installs
     - name: Install tensorflow/pytorch cpu version
-      if: runner.os == 'Linux' && steps.cache-python-env.outputs.cache-hit != true
+      if: runner.os == 'Linux' && steps.cache-python-env.outputs.cache-hit != 'true'
       shell: bash {0}
       run: |
         python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
         python3 -m pip install tensorflow-cpu
 
     - name: Upgrade pip
-      if: steps.cache-python-env.outputs.cache-hit != true
+      if: steps.cache-python-env.outputs.cache-hit != 'true'
       shell: bash {0}
       run: |
         python3 -m pip install -e .[${{ inputs.extras-require }}]

--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -8,7 +8,7 @@ inputs:
   extras-require:
     required: false
     description: "The extras dependencies packages to be installed, for instance 'docs' or 'publishing,notebooks'."
-    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -50,7 +50,7 @@ runs:
         python3 -m pip install -e .[dev]
 
     - name: Install DIANNA extras
-      if: ${{ inputs.extras-require != "" }}
+      if: ${{ inputs.extras-require }}
       shell: bash {0}
       run: |
         python3 -m pip install -e .[${{ inputs.extras-require }}]


### PR DESCRIPTION
This PR skips the pip install step if the cache is restored. This saves a couple of minutes on every workflow run.

Saves:
- Windows: ~3 min
- Ubuntu: ~1 min
- Mac: ~3 min