### PR TITLE
Improve test suite time by 25%

### DIFF
--- a/tests/test_common_usage.py
+++ b/tests/test_common_usage.py
@@ -6,7 +6,7 @@ from tests.utils import run_model
 
 def test_common_RISE_image_pipeline():  # noqa: N802 ignore case
     """No errors thrown while creating a relevance map and visualizing it."""
-    input_image = np.random.random((224, 224, 3))
+    input_image = np.random.random((5, 5, 3))
     axis_labels = {-1: 'channels'}
     labels = [0, 1]
 

--- a/tests/test_common_usage.py
+++ b/tests/test_common_usage.py
@@ -10,9 +10,15 @@ def test_common_RISE_image_pipeline():  # noqa: N802 ignore case
     axis_labels = {-1: 'channels'}
     labels = [0, 1]
 
-    heatmap = dianna.explain_image(run_model, input_image, "RISE", labels, axis_labels=axis_labels)[0]
+    heatmap = dianna.explain_image(run_model,
+                                   input_image,
+                                   'RISE',
+                                   labels,
+                                   axis_labels=axis_labels)[0]
     dianna.visualization.plot_image(heatmap, show_plot=False)
-    dianna.visualization.plot_image(heatmap, original_data=input_image[0], show_plot=False)
+    dianna.visualization.plot_image(heatmap,
+                                    original_data=input_image[0],
+                                    show_plot=False)
 
 
 def test_common_RISE_timeseries_pipeline():  # noqa: N802 ignore case
@@ -20,7 +26,8 @@ def test_common_RISE_timeseries_pipeline():  # noqa: N802 ignore case
     input_timeseries = np.random.random((31, 1))
     labels = [0]
 
-    heatmap = dianna.explain_timeseries(run_model, input_timeseries, "RISE", labels)[0]
+    heatmap = dianna.explain_timeseries(run_model, input_timeseries, 'RISE',
+                                        labels)[0]
     heatmap_channel = heatmap[:, 0]
     segments = []
     for i in range(len(heatmap_channel) - 1):
@@ -28,5 +35,9 @@ def test_common_RISE_timeseries_pipeline():  # noqa: N802 ignore case
             'index': i,
             'start': i,
             'stop': i + 1,
-            'weight': heatmap_channel[i]})
-    dianna.visualization.plot_timeseries(range(len(heatmap_channel)), input_timeseries[:, 0], segments, show_plot=False)
+            'weight': heatmap_channel[i]
+        })
+    dianna.visualization.plot_timeseries(range(len(heatmap_channel)),
+                                         input_timeseries[:, 0],
+                                         segments,
+                                         show_plot=False)


### PR DESCRIPTION
Hey, I noticed that some of the tests are quite slow. I had a quick look and noticed the RISE image pipeline test can be made about 20 times faster by reducing the shape of the image:

Before:
`28.10s call     tests/test_common_usage.py::test_common_RISE_image_pipeline`

After:
`1.74s call     tests/test_common_usage.py::test_common_RISE_image_pipeline`

Since we are testing the pipeline only, the size of the image is irrelevant (it's filled with random data anyway). This takes the time needed to run the tests down from 0:01:59 to 0:01:31 on my setup.