### PR TITLE
559 address duplication predict function

### DIFF
--- a/dianna/methods/lime_timeseries.py
+++ b/dianna/methods/lime_timeseries.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 from dianna import utils
 from dianna.utils.maskers import generate_masks
 from dianna.utils.maskers import mask_data
+from dianna.utils.predict import make_predictions
 
 
 class LIMETimeseries:
@@ -89,7 +90,7 @@ class LIMETimeseries:
         masks[0, :, :] = 1.0
         masked = mask_data(input_timeseries, masks, mask_type=mask_type)
         # generate predictions using the masked data.
-        predictions = self._make_predictions(masked, runner, batch_size)
+        predictions = make_predictions(masked, runner, batch_size)
         # need to reshape for the calculation of distance
         _, sequence, n_var = masked.shape
         masked = masked.reshape((-1, sequence * n_var))
@@ -188,23 +189,3 @@ class LIMETimeseries:
             ]
         )
         return distance
-
-    # TODO: duplication code from rise_timeseries. Need to put it in util.py
-    def _make_predictions(self, masked_data, runner, batch_size):
-        """Make predictions for the masked data.
-
-        Process the masked_data with the model runner and return the predictions.
-
-        Args:
-            masked_data (np.ndarray): An array of masked input data to be processed by the model.
-            runner (object): An object that runs the model on the input data and returns the predictions.
-            batch_size (int): The number of masked inputs to process in each batch.
-
-        Returns:
-            np.ndarray: An array of predictions made by the model on the input data.
-        """
-        number_of_masks = masked_data.shape[0]
-        predictions = []
-        for i in tqdm(range(0, number_of_masks, batch_size), desc="Explaining"):
-            predictions.append(runner(masked_data[i : i + batch_size]))
-        return np.concatenate(predictions)

--- a/dianna/methods/lime_timeseries.py
+++ b/dianna/methods/lime_timeseries.py
@@ -3,7 +3,6 @@ import sklearn
 from fastdtw import fastdtw
 from lime import explanation
 from lime import lime_base
-from tqdm import tqdm
 from dianna import utils
 from dianna.utils.maskers import generate_masks
 from dianna.utils.maskers import mask_data

--- a/dianna/methods/rise.py
+++ b/dianna/methods/rise.py
@@ -3,7 +3,9 @@ from skimage.transform import resize
 from dianna import utils
 
 # To Do: remove this import when the method for different input type is splitted
-from dianna.methods.rise_timeseries import RISETimeseries  # noqa: F401 ignore unused import
+from dianna.methods.rise_timeseries import (
+    RISETimeseries,
+)  # noqa: F401 ignore unused import
 from dianna.utils.predict import make_predictions
 
 
@@ -13,14 +15,15 @@ def normalize(saliency, n_masks, p_keep):
 
 
 def _upscale(grid_i, up_size):
-    return resize(grid_i, up_size, order=1, mode='reflect', anti_aliasing=False)
+    return resize(grid_i, up_size, order=1, mode="reflect", anti_aliasing=False)
 
 
 class RISEText:
     """RISE implementation for text based on https://github.com/eclique/RISE/blob/master/Easy_start.ipynb."""
 
-    def __init__(self, n_masks=1000, feature_res=8, p_keep=None,
-                 preprocess_function=None):
+    def __init__(
+        self, n_masks=1000, feature_res=8, p_keep=None, preprocess_function=None
+    ):
         """RISE initializer.
 
         Args:
@@ -36,8 +39,9 @@ class RISEText:
         self.masks = None
         self.predictions = None
 
-    def explain(self, model_or_function, input_text, labels, tokenizer=None,
-                batch_size=100):
+    def explain(
+        self, model_or_function, input_text, labels, tokenizer=None, batch_size=100
+    ):
         """Runs the RISE explainer on text.
 
            The model will be called with masked versions of the input text.
@@ -54,67 +58,101 @@ class RISEText:
             Explanation heatmap for each class (np.ndarray).
         """
         if tokenizer is None:
-            raise ValueError('Please provide a tokenizer to explain_text.')
+            raise ValueError("Please provide a tokenizer to explain_text.")
 
-        runner = utils.get_function(model_or_function, preprocess_function=self.preprocess_function)
+        runner = utils.get_function(
+            model_or_function, preprocess_function=self.preprocess_function
+        )
         input_tokens = np.asarray(tokenizer.tokenize(input_text))
         num_tokens = len(input_tokens)
-        active_p_keep = self._determine_p_keep(input_tokens, runner, tokenizer) if self.p_keep is None else self.p_keep
+        active_p_keep = (
+            self._determine_p_keep(
+                input_tokens, runner, tokenizer, self.n_masks, batch_size
+            )
+            if self.p_keep is None
+            else self.p_keep
+        )
         input_shape = (num_tokens,)
-        self.masks = self._generate_masks(input_shape, active_p_keep,
-                                          self.n_masks)  # Expose masks for to make user inspection possible
-        masked_sentences = self._create_masked_sentences(input_tokens, self.masks, tokenizer)
-        saliencies = self._get_saliencies(runner, masked_sentences, num_tokens, batch_size, active_p_keep)
+        self.masks = self._generate_masks(
+            input_shape, active_p_keep, self.n_masks
+        )  # Expose masks for to make user inspection possible
+        masked_sentences = self._create_masked_sentences(
+            input_tokens, self.masks, tokenizer
+        )
+        saliencies = self._get_saliencies(
+            runner, masked_sentences, num_tokens, batch_size, active_p_keep
+        )
         return self._reshape_result(input_tokens, labels, saliencies)
 
-    def _determine_p_keep(self, input_text, runner, tokenizer, n_masks=100):
+    def _determine_p_keep(self, input_text, runner, tokenizer, n_masks, batch_size):
         """See n_mask default value https://github.com/dianna-ai/dianna/issues/24#issuecomment-1000152233."""
         p_keeps = np.arange(0.1, 1.0, 0.1)
         stds = []
         for p_keep in p_keeps:
-            std = self._calculate_mean_class_std(p_keep, runner, input_text, tokenizer, n_masks=n_masks)
+            std = self._calculate_mean_class_std(
+                p_keep, runner, input_text, tokenizer, n_masks, batch_size
+            )
             stds += [std]
         best_i = np.argmax(stds)
         best_p_keep = p_keeps[best_i]
-        print(f'Rise parameter p_keep was automatically determined at {best_p_keep}')
+        print(f"Rise parameter p_keep was automatically determined at {best_p_keep}")
         return best_p_keep
 
-    def _calculate_mean_class_std(self, p_keep, runner, input_text, tokenizer,
-                                  n_masks):
+    def _calculate_mean_class_std(
+        self, p_keep, runner, input_text, tokenizer, n_masks, batch_size
+    ):
         masks = self._generate_masks(input_text.shape, p_keep, n_masks)
         masked = self._create_masked_sentences(input_text, masks, tokenizer)
-        predictions = make_predictions(masked, runner, batch_size=50)
+        predictions = make_predictions(masked, runner, batch_size)
         std_per_class = predictions.std(axis=0)
         return np.max(std_per_class)
 
     def _generate_masks(self, input_shape, p_keep, n_masks):
-        masks = np.random.choice(a=(True, False), size=(n_masks,) + input_shape, p=(p_keep, 1 - p_keep))
+        masks = np.random.choice(
+            a=(True, False), size=(n_masks,) + input_shape, p=(p_keep, 1 - p_keep)
+        )
         return masks
 
     def _get_saliencies(self, runner, sentences, num_tokens, batch_size, p_keep):
         self.predictions = make_predictions(sentences, runner, batch_size)
-        unnormalized_saliency = self.predictions.T.dot(self.masks.reshape(self.n_masks, -1)).reshape(-1, num_tokens)
+        unnormalized_saliency = self.predictions.T.dot(
+            self.masks.reshape(self.n_masks, -1)
+        ).reshape(-1, num_tokens)
         return normalize(unnormalized_saliency, self.n_masks, p_keep)
 
     @staticmethod
     def _reshape_result(input_tokens, labels, saliencies):
         word_indices = list(range(len(input_tokens)))
-        return [list(zip(input_tokens, word_indices, saliencies[label])) for label in labels]
+        return [
+            list(zip(input_tokens, word_indices, saliencies[label])) for label in labels
+        ]
 
     def _create_masked_sentences(self, tokens, masks, tokenizer):
         tokens_masked_list = [
-            [token if keep else tokenizer.mask_token for token, keep in zip(tokens, mask)]
-            for mask in masks]
-        masked_sentences = [tokenizer.convert_tokens_to_string(tokens_masked)
-                            for tokens_masked in tokens_masked_list]
+            [
+                token if keep else tokenizer.mask_token
+                for token, keep in zip(tokens, mask)
+            ]
+            for mask in masks
+        ]
+        masked_sentences = [
+            tokenizer.convert_tokens_to_string(tokens_masked)
+            for tokens_masked in tokens_masked_list
+        ]
         return masked_sentences
 
 
 class RISEImage:
     """RISE implementation for images based on https://github.com/eclique/RISE/blob/master/Easy_start.ipynb."""
 
-    def __init__(self, n_masks=1000, feature_res=8, p_keep=None,
-                 axis_labels=None, preprocess_function=None):
+    def __init__(
+        self,
+        n_masks=1000,
+        feature_res=8,
+        p_keep=None,
+        axis_labels=None,
+        preprocess_function=None,
+    ):
         """RISE initializer.
 
         Args:
@@ -150,9 +188,15 @@ class RISEImage:
         Returns:
             Explanation heatmap for each class (np.ndarray).
         """
-        input_data, runner = self._prepare_input_data_and_model(input_data, model_or_function)
+        input_data, runner = self._prepare_input_data_and_model(
+            input_data, model_or_function
+        )
 
-        active_p_keep = self._determine_p_keep(input_data, runner) if self.p_keep is None else self.p_keep
+        active_p_keep = (
+            self._determine_p_keep(input_data, runner)
+            if self.p_keep is None
+            else self.p_keep
+        )
 
         # data shape without batch axis and channel axis
         img_shape = input_data.shape[1:3]
@@ -164,7 +208,9 @@ class RISEImage:
 
         self.predictions = make_predictions(masked, runner, batch_size)
 
-        saliency = self.predictions.T.dot(self.masks.reshape(self.n_masks, -1)).reshape(-1, *img_shape)
+        saliency = self.predictions.T.dot(self.masks.reshape(self.n_masks, -1)).reshape(
+            -1, *img_shape
+        )
         result = normalize(saliency, self.n_masks, active_p_keep)
         if labels is not None:
             result = result[list(labels)]
@@ -174,31 +220,41 @@ class RISEImage:
         """Prepares the input data as an xarray with an added batch dimension and creates a preprocessing function."""
         self._set_axis_labels(input_data)
         input_data = utils.to_xarray(input_data, self.axis_labels)
-        input_data = input_data.expand_dims('batch', 0)
+        input_data = input_data.expand_dims("batch", 0)
         input_data, full_preprocess_function = self._prepare_image_data(input_data)
-        runner = utils.get_function(model_or_function, preprocess_function=full_preprocess_function)
+        runner = utils.get_function(
+            model_or_function, preprocess_function=full_preprocess_function
+        )
         return input_data, runner
 
     def _set_axis_labels(self, input_data):
         # automatically determine the location of the channels axis if no axis_labels were provided
-        axis_label_names = self.axis_labels.values() if isinstance(self.axis_labels, dict) else self.axis_labels
+        axis_label_names = (
+            self.axis_labels.values()
+            if isinstance(self.axis_labels, dict)
+            else self.axis_labels
+        )
         if not axis_label_names:
             channels_axis_index = utils.locate_channels_axis(input_data.shape)
-            self.axis_labels = {channels_axis_index: 'channels'}
-        elif 'channels' not in axis_label_names:
-            raise ValueError("When providing axis_labels it is required to provide the location"
-                             " of the channels axis")
+            self.axis_labels = {channels_axis_index: "channels"}
+        elif "channels" not in axis_label_names:
+            raise ValueError(
+                "When providing axis_labels it is required to provide the location"
+                " of the channels axis"
+            )
 
     def _determine_p_keep(self, input_data, runner, n_masks=100):
         """See n_mask default value https://github.com/dianna-ai/dianna/issues/24#issuecomment-1000152233."""
         p_keeps = np.arange(0.1, 1.0, 0.1)
         stds = []
         for p_keep in p_keeps:
-            std = self._calculate_max_class_std(p_keep, runner, input_data, n_masks=n_masks)
+            std = self._calculate_max_class_std(
+                p_keep, runner, input_data, n_masks=n_masks
+            )
             stds += [std]
         best_i = np.argmax(stds)
         best_p_keep = p_keeps[best_i]
-        print(f'Rise parameter p_keep was automatically determined at {best_p_keep}')
+        print(f"Rise parameter p_keep was automatically determined at {best_p_keep}")
         return best_p_keep
 
     def _calculate_max_class_std(self, p_keep, runner, input_data, n_masks):
@@ -214,7 +270,7 @@ class RISEImage:
 
         Args:
             input_size (int): Size of a single sample of input data, for images without the channel axis.
-            p_keep: ?
+            p_keep: Fraction of input data to keep in each mask
             n_masks: Number of masks
 
         Returns:
@@ -223,9 +279,12 @@ class RISEImage:
         cell_size = np.ceil(np.array(input_size) / self.feature_res)
         up_size = (self.feature_res + 1) * cell_size
 
-        grid = np.random.choice(a=(True, False), size=(n_masks, self.feature_res, self.feature_res),
-                                p=(p_keep, 1 - p_keep))
-        grid = grid.astype('float32')
+        grid = np.random.choice(
+            a=(True, False),
+            size=(n_masks, self.feature_res, self.feature_res),
+            p=(p_keep, 1 - p_keep),
+        )
+        grid = grid.astype("float32")
 
         masks = np.empty((n_masks, *input_size), dtype=np.float32)
 
@@ -233,7 +292,9 @@ class RISEImage:
             y = np.random.randint(0, cell_size[0])
             x = np.random.randint(0, cell_size[1])
             # Linear upsampling and cropping
-            masks[i, :, :] = _upscale(grid[i], up_size)[y:y + input_size[0], x:x + input_size[1]]
+            masks[i, :, :] = _upscale(grid[i], up_size)[
+                y : y + input_size[0], x : x + input_size[1]
+            ]
         masks = masks.reshape(-1, *input_size, 1)
         return masks
 
@@ -247,11 +308,13 @@ class RISEImage:
             transformed input data, preprocessing function to use with utils.get_function()
         """
         # ensure channels axis is last and keep track of where it was so we can move it back
-        channels_axis_index = input_data.dims.index('channels')
-        input_data = utils.move_axis(input_data, 'channels', -1)
+        channels_axis_index = input_data.dims.index("channels")
+        input_data = utils.move_axis(input_data, "channels", -1)
         # create preprocessing function that puts model input generated by RISE into the right shape and dtype,
         # followed by running the user's preprocessing function
-        full_preprocess_function = self._get_full_preprocess_function(channels_axis_index, input_data.dtype)
+        full_preprocess_function = self._get_full_preprocess_function(
+            channels_axis_index, input_data.dtype
+        )
         return input_data, full_preprocess_function
 
     def _get_full_preprocess_function(self, channel_axis_index, dtype):
@@ -268,8 +331,13 @@ class RISEImage:
             Function that first ensures the data has the same shape and type as the input data,
             then runs the users' preprocessing function
         """
+
         def moveaxis_function(data):
-            return utils.move_axis(data, 'channels', channel_axis_index).astype(dtype).values
+            return (
+                utils.move_axis(data, "channels", channel_axis_index)
+                .astype(dtype)
+                .values
+            )
 
         if self.preprocess_function is None:
             return moveaxis_function

--- a/dianna/methods/rise.py
+++ b/dianna/methods/rise.py
@@ -1,11 +1,10 @@
 import numpy as np
 from skimage.transform import resize
-from tqdm import tqdm
 from dianna import utils
-from dianna.utils.predict import make_predictions
 
 # To Do: remove this import when the method for different input type is splitted
 from dianna.methods.rise_timeseries import RISETimeseries  # noqa: F401 ignore unused import
+from dianna.utils.predict import make_predictions
 
 
 def normalize(saliency, n_masks, p_keep):

--- a/dianna/methods/rise.py
+++ b/dianna/methods/rise.py
@@ -3,9 +3,7 @@ from skimage.transform import resize
 from dianna import utils
 
 # To Do: remove this import when the method for different input type is splitted
-from dianna.methods.rise_timeseries import (
-    RISETimeseries,
-)  # noqa: F401 ignore unused import
+from dianna.methods.rise_timeseries import RISETimeseries  # noqa: F401 ignore unused import
 from dianna.utils.predict import make_predictions
 
 

--- a/dianna/methods/rise_timeseries.py
+++ b/dianna/methods/rise_timeseries.py
@@ -3,15 +3,7 @@ from tqdm import tqdm
 from dianna import utils
 from dianna.utils.maskers import generate_masks
 from dianna.utils.maskers import mask_data
-
-
-def _make_predictions(input_data, runner, batch_size):
-    """Process the input_data with the model runner in batches and return the predictions."""
-    number_of_masks = input_data.shape[0]
-    batch_predictions = []
-    for i in tqdm(range(0, number_of_masks, batch_size), desc='Explaining'):
-        batch_predictions.append(runner(input_data[i:i + batch_size]))
-    return np.concatenate(batch_predictions)
+from dianna.utils.predict import make_predictions
 
 
 # TODO: Duplicate code from rise.py:
@@ -61,7 +53,7 @@ class RISETimeseries:
         self.masks = generate_masks(input_timeseries, number_of_masks=self.n_masks, p_keep=self.p_keep)
         masked = mask_data(input_timeseries, self.masks, mask_type=mask_type)
 
-        self.predictions = _make_predictions(masked, runner, batch_size)
+        self.predictions = make_predictions(masked, runner, batch_size)
         n_labels = self.predictions.shape[1]
 
         saliency = self.predictions.T.dot(self.masks.reshape(self.n_masks, -1)).reshape(n_labels,

--- a/dianna/methods/rise_timeseries.py
+++ b/dianna/methods/rise_timeseries.py
@@ -1,5 +1,3 @@
-import numpy as np
-from tqdm import tqdm
 from dianna import utils
 from dianna.utils.maskers import generate_masks
 from dianna.utils.maskers import mask_data

--- a/dianna/utils/maskers.py
+++ b/dianna/utils/maskers.py
@@ -36,7 +36,7 @@ def generate_channel_masks(input_data: np.ndarray, number_of_masks: int, p_keep:
     number_of_channels = input_data.shape[1]
     number_of_channels_masked = _determine_number_masked(p_keep, number_of_channels)
     masked_data_shape = [number_of_masks] + list(input_data.shape)
-    masks = np.ones(masked_data_shape, dtype=np.bool)
+    masks = np.ones(masked_data_shape, dtype=bool)
     for i in range(number_of_masks):
         channels_to_mask = np.random.choice(number_of_channels, number_of_channels_masked, False)
         masks[i, :, channels_to_mask] = False
@@ -48,7 +48,7 @@ def generate_time_step_masks(input_data: np.ndarray, number_of_masks: int, p_kee
     series_length = input_data.shape[0]
     number_of_steps_masked = _determine_number_masked(p_keep, series_length)
     masked_data_shape = [number_of_masks] + list(input_data.shape)
-    masks = np.ones(masked_data_shape, dtype=np.bool)
+    masks = np.ones(masked_data_shape, dtype=bool)
     for i in range(number_of_masks):
         steps_to_mask = np.random.choice(series_length, number_of_steps_masked, False)
         masks[i, steps_to_mask] = False

--- a/dianna/utils/predict.py
+++ b/dianna/utils/predict.py
@@ -1,0 +1,22 @@
+import numpy as np
+from tqdm import tqdm
+
+
+def make_predictions(data, runner, batch_size):
+    """Make predictions with the input data.
+
+    Process the data with the model runner and return the predictions.
+
+    Args:
+        data (np.ndarray): An array of masked input data to be processed by the model.
+        runner (object): An object that runs the model on the input data and returns predictions.
+        batch_size (int): The number of masked inputs to process in each batch.
+
+    Returns:
+        np.ndarray: An array of predictions made by the model on the input data.
+    """
+    number_of_masks = data.shape[0]
+    predictions = []
+    for i in tqdm(range(0, number_of_masks, batch_size), desc="Explaining"):
+        predictions.append(runner(data[i : i + batch_size]))
+    return np.concatenate(predictions)

--- a/dianna/utils/predict.py
+++ b/dianna/utils/predict.py
@@ -15,7 +15,7 @@ def make_predictions(data, runner, batch_size):
     Returns:
         np.ndarray: An array of predictions made by the model on the input data.
     """
-    number_of_masks = data.shape[0]
+    number_of_masks = len(data)
     predictions = []
     for i in tqdm(range(0, number_of_masks, batch_size), desc="Explaining"):
         predictions.append(runner(data[i : i + batch_size]))

--- a/tests/test_rise.py
+++ b/tests/test_rise.py
@@ -19,12 +19,19 @@ class RiseOnImages(TestCase):
     def test_rise_function():
         """Test if rise runs and outputs the correct shape given some data and a model function."""
         input_data = np.random.random((224, 224, 3))
-        axis_labels = ['y', 'x', 'channels']
+        axis_labels = ["y", "x", "channels"]
         labels = [1]
-        heatmaps_expected = np.load('tests/test_data/heatmap_rise_function.npy')
+        heatmaps_expected = np.load("tests/test_data/heatmap_rise_function.npy")
 
-        heatmaps = dianna.explain_image(run_model, input_data, "RISE", labels, axis_labels=axis_labels, n_masks=200,
-                                        p_keep=.5)
+        heatmaps = dianna.explain_image(
+            run_model,
+            input_data,
+            "RISE",
+            labels,
+            axis_labels=axis_labels,
+            n_masks=200,
+            p_keep=0.5,
+        )
 
         assert heatmaps[0].shape == input_data.shape[:2]
         assert np.allclose(heatmaps, heatmaps_expected, atol=1e-5)
@@ -32,12 +39,14 @@ class RiseOnImages(TestCase):
     @staticmethod
     def test_rise_filename():
         """Test if rise runs and outputs the correct shape given some data and a model file."""
-        model_filename = 'tests/test_data/mnist_model.onnx'
+        model_filename = "tests/test_data/mnist_model.onnx"
         input_data = generate_data(batch_size=1).astype(np.float32)[0]
-        heatmaps_expected = np.load('tests/test_data/heatmap_rise_filename.npy')
+        heatmaps_expected = np.load("tests/test_data/heatmap_rise_filename.npy")
         labels = [1]
 
-        heatmaps = dianna.explain_image(model_filename, input_data, "RISE", labels, n_masks=200, p_keep=.5)
+        heatmaps = dianna.explain_image(
+            model_filename, input_data, "RISE", labels, n_masks=200, p_keep=0.5
+        )
 
         assert heatmaps[0].shape == input_data.shape[1:]
         print(heatmaps_expected.shape)
@@ -47,12 +56,11 @@ class RiseOnImages(TestCase):
     def test_rise_determine_p_keep_for_images():
         """Tests exact expected p_keep given an image and model."""
         np.random.seed(0)
-        expected_p_exact_keep = .4
-        model_filename = 'tests/test_data/mnist_model.onnx'
+        expected_p_exact_keep = 0.4
+        model_filename = "tests/test_data/mnist_model.onnx"
         data = get_mnist_1_data().astype(np.float32)
 
-        p_keep = RISEImage()._determine_p_keep(
-            data, get_function(model_filename))
+        p_keep = RISEImage()._determine_p_keep(data, get_function(model_filename))
 
         assert np.isclose(p_keep, expected_p_exact_keep)
 
@@ -62,26 +70,42 @@ class RiseOnText(TestCase):
 
     def test_rise_text(self):
         """Tests exact expected output given a text and model."""
-        review = 'such a bad movie'
-        expected_words = ['such', 'a', 'bad', 'movie']
+        review = "such a bad movie"
+        expected_words = ["such", "a", "bad", "movie"]
         expected_word_indices = [0, 1, 2, 3]
         expected_positive_scores = [0.30, 0.29, 0.04, 0.25]
 
-        positive_explanation = dianna.explain_text(self.runner, review, tokenizer=self.runner.tokenizer,
-                                                   labels=(1, 0), method='RISE', p_keep=.5)[0]
+        positive_explanation = dianna.explain_text(
+            self.runner,
+            review,
+            tokenizer=self.runner.tokenizer,
+            labels=(1, 0),
+            method="RISE",
+            p_keep=0.5,
+        )[0]
 
-        assert_explanation_satisfies_expectations(positive_explanation, expected_positive_scores, expected_word_indices,
-                                                  expected_words)
+        assert_explanation_satisfies_expectations(
+            positive_explanation,
+            expected_positive_scores,
+            expected_word_indices,
+            expected_words,
+        )
 
     def test_rise_determine_p_keep_for_text(self):
         """Tests exact expected p_keep given a text and model."""
-        expected_p_exact_keep = .7
-        input_text = 'such a bad movie'
+        expected_p_exact_keep = 0.7
+        input_text = "such a bad movie"
         runner = get_function(self.runner)
         input_tokens = np.asarray(runner.tokenizer.tokenize(input_text))
 
-        p_keep = RISEText()._determine_p_keep(input_tokens, runner,  # pylint: disable=protected-access
-                                              runner.tokenizer)
+        # pylint: disable=protected-access
+        p_keep = RISEText()._determine_p_keep(
+            input_tokens,
+            runner,
+            runner.tokenizer,
+            n_masks=100,
+            batch_size=100,
+        )
         assert np.isclose(p_keep, expected_p_exact_keep)
 
     def setUp(self) -> None:


### PR DESCRIPTION
In this PR we refactor `lime_timeseries`, `rise_timeseries` and `rise` to remove the duplicated prediction function in the code.

Also includes some minor refactoring changes.

Fixes #559.