### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,9 @@
 version: 2
+
+build:
+  tools:
+    python: "3.9"
+
 python:
   install:
     - method: pip


### PR DESCRIPTION
This PR fixes the rtd build by bumping the python version to 3.9.

This was broken, because we dropped support for Python 3.7 recently (#588), and rtd by default builds in 3.7.