### PR TITLE
Exclude coverage check for dashboard

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,5 @@ sonar.links.ci=https://github.com/dianna-ai/dianna/actions
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.xunit.reportPath=xunit-result.xml
 sonar.python.pylint.reportPaths=pylint-report.txt
+# Exclude test subdirectories from source scope
+sonar.coverage.exclusions = dianna/dashboard/**


### PR DESCRIPTION
`dashboard` is checked but since it is checked within subprocess it is not detected by sonarcloud coverage. This produces misleading results. So it is better to exclude the coverage check for dashboard from the report.