### PR TITLE
fixed number of segments bug

### DIFF
--- a/dianna/methods/kernelshap.py
+++ b/dianna/methods/kernelshap.py
@@ -116,6 +116,7 @@ class KERNELSHAPImage:
         self.image_segments = self._segment_image(self.input_data, n_segments,
                                                   compactness, sigma,
                                                   **slic_kwargs)
+        n_segments = np.unique(self.image_segments).size
 
         # call the Kernel SHAP explainer
         explainer = shap.KernelExplainer(

--- a/tests/test_kernelshap.py
+++ b/tests/test_kernelshap.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 import numpy as np
+import skimage.segmentation
 from dianna.methods.kernelshap import KERNELSHAPImage
 
 
@@ -63,5 +64,7 @@ class ShapOnImages(TestCase):
             compactness=10.0,
             sigma=0,
         )
+        segments = skimage.segmentation.slic(input_data, n_segments=n_segments)
+        n_segments = np.unique(segments).size
 
         assert shap_values[0].shape == np.zeros((1, n_segments)).shape

--- a/tests/test_kernelshap.py
+++ b/tests/test_kernelshap.py
@@ -64,7 +64,11 @@ class ShapOnImages(TestCase):
             compactness=10.0,
             sigma=0,
         )
-        segments = skimage.segmentation.slic(input_data, n_segments=n_segments)
+        segments = skimage.segmentation.slic(image=input_data.reshape(28, 28, 1),
+                                             n_segments=n_segments,
+                                             compactness=10.0,
+                                             sigma=0.)
         n_segments = np.unique(segments).size
 
         assert shap_values[0].shape == np.zeros((1, n_segments)).shape
+

--- a/tests/test_kernelshap.py
+++ b/tests/test_kernelshap.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 import numpy as np
-import skimage.segmentation
 from dianna.methods.kernelshap import KERNELSHAPImage
 
 
@@ -54,7 +53,7 @@ class ShapOnImages(TestCase):
         n_segments = 50
         explainer = KERNELSHAPImage()
         labels = [0]
-        shap_values, _ = explainer.explain(
+        shap_values, segments = explainer.explain(
             onnx_model_path,
             input_data,
             labels,
@@ -64,11 +63,6 @@ class ShapOnImages(TestCase):
             compactness=10.0,
             sigma=0,
         )
-        segments = skimage.segmentation.slic(image=input_data.reshape(28, 28, 1),
-                                             n_segments=n_segments,
-                                             compactness=10.0,
-                                             sigma=0.)
+        # Check if shapeley values match number of segments
         n_segments = np.unique(segments).size
-
         assert shap_values[0].shape == np.zeros((1, n_segments)).shape
-


### PR DESCRIPTION
This PR fixes #631. In some cases, kernelshap would over- or (worse) underallocate memory for the shapeley values leading to issues. This PR should fix this bug. 