### PR TITLE
fix deprecation warning:

### DIFF
--- a/dianna/utils/maskers.py
+++ b/dianna/utils/maskers.py
@@ -104,7 +104,8 @@ def _determine_number_masked(p_keep: float, series_length: int) -> int:
     ceil = np.ceil(mean)
     if floor != ceil:
         user_requested_steps = int(
-            np.random.choice([floor, ceil], 1, p=[ceil - mean, mean - floor]))
+            np.random.choice([floor, ceil], 1, p=[ceil - mean,
+                                                  mean - floor])[0])
     else:
         user_requested_steps = int(floor)
 


### PR DESCRIPTION
Gets rid of following warning:
/Users/runner/work/dianna/dianna/dianna/utils/maskers.py:106: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.) 

See in log: https://github.com/dianna-ai/dianna/actions/runs/8250917332/job/22566702492#step:4:622 line 571