### PR TITLE
fix macos + 3.11 build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     onnx==1.14.1
     onnx_tf
     onnxruntime
-    shap
+    shap<0.45
     scikit-image>=0.19.3
     scikit-learn
     tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     xarray
     # tf and tfprob are required but not declared by onnx_tf
     tensorflow >= 2.12,<2.16
-    tensorflow_probability
+    tensorflow_probability <2.24
     # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
     importlib_resources;python_version<'3.10'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     xarray
     # tf and tfprob are required but not declared by onnx_tf
     tensorflow >= 2.12,<2.16
-    tensorflow_probability <2.24
+    tensorflow_probability <0.24
     # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
     importlib_resources;python_version<'3.10'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     tqdm
     xarray
     # tf and tfprob are required but not declared by onnx_tf
-    tensorflow >= 2.12
+    tensorflow >= 2.12,<2.16
     tensorflow_probability
     # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
     importlib_resources;python_version<'3.10'


### PR DESCRIPTION
See https://github.com/dianna-ai/dianna/actions/runs/8250917332/job/22566702492#step:4:622 All builds [3.9,3.11]X[win, ubuntu,mac] pass except (mac,3.9). I think it's because it is using a new tf version 2.16 where the others are using 2.15. I also replicated this behavior locally but couldn't completely pinpoint the cause. It may also have something to do with the tensorflow-probability version.
I put another constraint on the tf version that will hopefully solve this for now.