### PR TITLE
Add test for rise timeseries on onnx file

### DIFF
--- a/tests/methods/test_rise_timeseries.py
+++ b/tests/methods/test_rise_timeseries.py
@@ -12,10 +12,34 @@ def test_rise_timeseries_correct_output_shape():
     input_data = np.random.random((10, 1))
     labels = [1]
 
-    heatmaps = dianna.explain_timeseries(run_model, input_data, "RISE", labels,
-                                         n_masks=200, p_keep=.5)
+    heatmaps = dianna.explain_timeseries(run_model,
+                                         input_data,
+                                         "RISE",
+                                         labels,
+                                         n_masks=200,
+                                         p_keep=.5)
 
     assert heatmaps.shape == (len(labels), *input_data.shape)
+
+
+def test_rise_timeseries_with_model_file():
+    """Test if rise runs and outputs the correct shape given some data and a model file."""
+    filename = 'dianna/models/season_prediction_model_temp_max_binary.onnx'
+    input_data = np.random.random((28, 1))
+    labels = [0]
+
+    # this model requires float input, while numpy uses double
+    def preprocess(data):
+        return data.astype(np.float32)
+
+    heatmaps = dianna.explain_timeseries(filename,
+                                         input_data,
+                                         "RISE",
+                                         labels,
+                                         n_masks=200,
+                                         p_keep=.5,
+                                         preprocess_function=preprocess)
+    print(heatmaps.shape)
 
 
 @pytest.mark.parametrize('series_length', [


### PR DESCRIPTION
Closes #690 

#690 describes the explainer not working with an onnx file for timeseries. After some testing, I found that the season prediction model requires float32 input, while numpy/python use float64 by default. This makes the season prediction model crash when using the onnx file. I don't think this should be considered a bug in dianna, rather the user should convert the data using the preprocess function. I added a test that does this.