### PR TITLE
Fix data file paths for Colab

### DIFF
--- a/dianna/dashboard/_movie_model.py
+++ b/dianna/dashboard/_movie_model.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-from _shared import label_directory
+from _shared import data_directory
 from scipy.special import expit as sigmoid
 from torchtext.vocab import Vectors
 from dianna import utils
@@ -13,7 +13,7 @@ class MovieReviewsModelRunner:
     def __init__(self, model, word_vectors=None, max_filter_size=5):
         """Initializes the class."""
         if word_vectors is None:
-            word_vectors = label_directory / 'movie_reviews_word_vectors.txt'
+            word_vectors = data_directory / 'movie_reviews_word_vectors.txt'
 
         self.run_model = utils.get_function(model)
         self.vocab = Vectors(word_vectors, cache=os.path.dirname(word_vectors))

--- a/tutorials/explainers/KernelSHAP/kernelshap_geometric_shapes.ipynb
+++ b/tutorials/explainers/KernelSHAP/kernelshap_geometric_shapes.ipynb
@@ -36,15 +36,8 @@
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./data/shapes.npz', './models/geometric_shapes_model.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -64,6 +57,7 @@
    },
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "import warnings\n",
     "warnings.filterwarnings('ignore') # disable warnings relateds to versions of tf\n",
     "import numpy as np\n",
@@ -71,7 +65,8 @@
     "import onnx\n",
     "from onnx_tf.backend import prepare\n",
     "import matplotlib.pyplot as plt\n",
-    "from pathlib import Path"
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
@@ -108,7 +103,7 @@
    "outputs": [],
    "source": [
     "# load dataset\n",
-    "data = np.load(Path('..','..','..','dianna', 'data', 'shapes.npz'))\n",
+    "data = np.load(Path(root_dir, 'data', 'shapes.npz'))\n",
     "# load testing data and the related labels\n",
     "X_test = data['X_test'].astype(np.float32).reshape([-1, 1, 64, 64])\n",
     "y_test = data['y_test']"
@@ -136,7 +131,7 @@
    "outputs": [],
    "source": [
     "# Load saved onnx model\n",
-    "onnx_model_path = Path('..','..','..','dianna','models', 'geometric_shapes_model.onnx')\n",
+    "onnx_model_path = Path(root_dir, 'models', 'geometric_shapes_model.onnx')\n",
     "onnx_model = onnx.load(onnx_model_path)\n",
     "# get the output node\n",
     "output_node = prepare(onnx_model, gen_tensor_dict=True).outputs[0]"
@@ -366,7 +361,7 @@
    "hash": "e7604e8ec5f09e490e10161e37a4725039efd3ab703d81b1b8a1e00d6741866c"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -380,7 +375,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/KernelSHAP/kernelshap_mnist.ipynb
+++ b/tutorials/explainers/KernelSHAP/kernelshap_mnist.ipynb
@@ -36,15 +36,8 @@
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./data/binary-mnist.npz', './models/mnist_model_tf.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -64,14 +57,14 @@
    },
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "import warnings\n",
     "warnings.filterwarnings('ignore') # disable warnings relateds to versions of tf\n",
     "import numpy as np\n",
     "import dianna\n",
     "import onnx\n",
     "from onnx_tf.backend import prepare\n",
-    "import matplotlib.pyplot as plt\n",
-    "from pathlib import Path"
+    "import matplotlib.pyplot as plt"
    ]
   },
   {
@@ -108,7 +101,7 @@
    "outputs": [],
    "source": [
     "# load dataset\n",
-    "data = np.load(Path('..','..','..','dianna','data', 'binary-mnist.npz'))\n",
+    "data = np.load(Path(root_dir, 'data', 'binary-mnist.npz'))\n",
     "# load testing data and the related labels\n",
     "X_test = data['X_test'].astype(np.float32).reshape([-1, 28, 28, 1]) / 255\n",
     "y_test = data['y_test']"
@@ -136,7 +129,7 @@
    "outputs": [],
    "source": [
     "# Load saved onnx model\n",
-    "onnx_model_path = Path('..','..','..','dianna','models', 'mnist_model_tf.onnx')\n",
+    "onnx_model_path = Path(root_dir, 'models', 'mnist_model_tf.onnx')\n",
     "onnx_model = onnx.load(onnx_model_path)\n",
     "# get the output node\n",
     "output_node = prepare(onnx_model, gen_tensor_dict=True).outputs[0]"
@@ -333,7 +326,7 @@
    "hash": "e7604e8ec5f09e490e10161e37a4725039efd3ab703d81b1b8a1e00d6741866c"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -347,7 +340,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/KernelSHAP/kernelshap_mnist.ipynb
+++ b/tutorials/explainers/KernelSHAP/kernelshap_mnist.ipynb
@@ -64,7 +64,9 @@
     "import dianna\n",
     "import onnx\n",
     "from onnx_tf.backend import prepare\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {

--- a/tutorials/explainers/KernelSHAP/kernelshap_tabular_penguin.ipynb
+++ b/tutorials/explainers/KernelSHAP/kernelshap_tabular_penguin.ipynb
@@ -25,15 +25,8 @@
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./models/penguin_model.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -49,6 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "import dianna\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -59,7 +53,9 @@
     "from numba.core.errors import NumbaDeprecationWarning\n",
     "import warnings\n",
     "# silence the Numba deprecation warnings in shap\n",
-    "warnings.simplefilter('ignore', category=NumbaDeprecationWarning)"
+    "warnings.simplefilter('ignore', category=NumbaDeprecationWarning)\n",
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
@@ -308,7 +304,7 @@
    ],
    "source": [
     "# load onnx model and check the prediction with it\n",
-    "model_path = '../../../dianna/models/penguin_model.onnx'\n",
+    "model_path = Path(root_dir, 'models', 'penguin_model.onnx')\n",
     "loaded_model = SimpleModelRunner(model_path)\n",
     "predictions = loaded_model(data_instance.reshape(1,-1).astype(np.float32))\n",
     "species[np.argmax(predictions)]"
@@ -411,7 +407,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -425,7 +421,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/KernelSHAP/kernelshap_tabular_weather.ipynb
+++ b/tutorials/explainers/KernelSHAP/kernelshap_tabular_weather.ipynb
@@ -27,15 +27,8 @@
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os\n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./models/sunshine_hours_regression_model.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -51,6 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "import dianna\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -60,7 +54,9 @@
     "from numba.core.errors import NumbaDeprecationWarning\n",
     "import warnings\n",
     "# silence the Numba deprecation warnings in shap\n",
-    "warnings.simplefilter('ignore', category=NumbaDeprecationWarning)"
+    "warnings.simplefilter('ignore', category=NumbaDeprecationWarning)\n",
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
@@ -257,7 +253,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -271,7 +267,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/LIME/lime_images.ipynb
+++ b/tutorials/explainers/LIME/lime_images.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "ee4265e1",
    "metadata": {},
    "source": [
     "<img width=\"150\" alt=\"Logo_ER10\" src=\"https://user-images.githubusercontent.com/3244249/151994514-b584b984-a148-4ade-80ee-0f88b0aefa45.png\">\n",
@@ -17,6 +18,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c95ba197",
    "metadata": {},
    "source": [
     "#### Colab Setup"
@@ -25,24 +27,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "2e9c8235",
    "metadata": {},
    "outputs": [],
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./data/leafsnap_example_acer_rubrum.jpg', './labels/leafsnap_classes.csv', './models/leafsnap_model.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "c64001a2",
    "metadata": {},
    "source": [
     "#### 0 -  Imports and paths"
@@ -51,6 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "c1d68e0a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,23 +58,27 @@
     "from pathlib import Path\n",
     "\n",
     "import dianna\n",
-    "from dianna import visualization"
+    "from dianna import visualization\n",
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "19dfbe90",
    "metadata": {},
    "outputs": [],
    "source": [
     "true_species = 'acer_rubrum'\n",
-    "image_path = Path('..','..','..','dianna','data', f'leafsnap_example_{true_species}.jpg')\n",
-    "model_path = Path('..','..','..','dianna','models', 'leafsnap_model.onnx')\n",
-    "model_classes_path = Path('..','..','..','dianna','labels' ,'leafsnap_classes.csv')"
+    "image_path = Path(root_dir, 'data', f'leafsnap_example_{true_species}.jpg')\n",
+    "model_path = Path(root_dir, 'models', 'leafsnap_model.onnx')\n",
+    "model_classes_path = Path(root_dir, 'labels' ,'leafsnap_classes.csv')"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "1a3bd4d0",
    "metadata": {},
    "source": [
     "#### 1 -  Loading the data\n",
@@ -91,6 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "713da9c2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,6 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "2874fde6",
    "metadata": {},
    "outputs": [
     {
@@ -118,7 +122,7 @@
    ],
    "source": [
     "# load and plot the example image\n",
-    "img = np.array(Image.open(Path('..','..','..','dianna','data', f'leafsnap_example_{true_species}.jpg')))\n",
+    "img = np.array(Image.open(Path(root_dir, 'data', f'leafsnap_example_{true_species}.jpg')))\n",
     "\n",
     "plt.imshow(img)\n",
     "plt.title(f'Species: {true_species}');\n",
@@ -134,6 +138,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "274f139f",
    "metadata": {},
    "source": [
     "#### 2 -  Applying LIME with DIANNA\n",
@@ -148,6 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "d0e0c538",
    "metadata": {},
    "outputs": [
     {
@@ -172,6 +178,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c723b227",
    "metadata": {},
    "source": [
     "#### 3 - Visualization\n",
@@ -182,6 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
+   "id": "60313b5e",
    "metadata": {},
    "outputs": [
     {
@@ -219,6 +227,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e6ff4466",
    "metadata": {},
    "source": [
     "The output heatmap is not very informative, there are only a few large blocks without much detail.  \n",
@@ -231,6 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
+   "id": "97af9cde",
    "metadata": {},
    "outputs": [
     {
@@ -256,6 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
+   "id": "4b20c81b",
    "metadata": {},
    "outputs": [
     {
@@ -294,6 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d914f480",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -301,7 +313,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -315,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/tutorials/explainers/LIME/lime_tabular_penguin.ipynb
+++ b/tutorials/explainers/LIME/lime_tabular_penguin.ipynb
@@ -27,15 +27,8 @@
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./models/penguin_model.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "      # install dianna\n",
+    "      !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -51,12 +44,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "import dianna\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import seaborn as sns\n",
     "from sklearn.model_selection import train_test_split\n",
-    "from dianna.utils.onnx_runner import SimpleModelRunner"
+    "from dianna.utils.onnx_runner import SimpleModelRunner\n",
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
@@ -305,7 +301,7 @@
    ],
    "source": [
     "# load onnx model and check the prediction with it\n",
-    "model_path = '../../../dianna/models/penguin_model.onnx'\n",
+    "model_path = Path(root_dir, 'models', 'penguin_model.onnx')\n",
     "loaded_model = SimpleModelRunner(model_path)\n",
     "predictions = loaded_model(data_instance.reshape(1,-1).astype(np.float32))\n",
     "species[np.argmax(predictions)]"
@@ -408,7 +404,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -422,7 +418,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/LIME/lime_tabular_weather.ipynb
+++ b/tutorials/explainers/LIME/lime_tabular_weather.ipynb
@@ -27,15 +27,8 @@
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os\n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./models/sunshine_hours_regression_model.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -51,11 +44,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "import dianna\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from sklearn.model_selection import train_test_split\n",
-    "from dianna.utils.onnx_runner import SimpleModelRunner"
+    "from dianna.utils.onnx_runner import SimpleModelRunner\n",
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
@@ -156,7 +152,7 @@
    ],
    "source": [
     "# load onnx model and check the prediction with it\n",
-    "model_path = '../../../dianna//models/sunshine_hours_regression_model.onnx'\n",
+    "model_path = Path(root_dir, 'models', 'sunshine_hours_regression_model.onnx')\n",
     "loaded_model = SimpleModelRunner(model_path)\n",
     "predictions = loaded_model(data_instance.reshape(1,-1).astype(np.float32))\n",
     "predictions"
@@ -266,7 +262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/LIME/lime_text.ipynb
+++ b/tutorials/explainers/LIME/lime_text.ipynb
@@ -32,25 +32,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pathlib import Path\n",
-    "\n",
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
     "    # install dianna\n",
-    "    !python3 -m pip install dianna[notebooks]\n",
-    "\n",
-    "    # download data used in this demo\n",
-    "    import os\n",
-    "    base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "    paths_to_download = ['./data/movie_reviews_word_vectors.txt', './models/movie_review_model.onnx']\n",
-    "    for path in paths_to_download:\n",
-    "        !wget {base_url + path} -P {os.path.dirname(path)}\n",
-    "\n",
-    "    root_dir = Path(\".\").absolute()\n",
-    "else:\n",
-    "    # assume dianna is already installed, use data from the install folder\n",
-    "    import dianna\n",
-    "    root_dir = Path(dianna.__file__).parent"
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -77,6 +62,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "from pathlib import Path\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import spacy\n",
@@ -85,7 +71,9 @@
     "\n",
     "from dianna import visualization\n",
     "from dianna import utils\n",
-    "from dianna.utils.tokenizers import SpacyTokenizer"
+    "from dianna.utils.tokenizers import SpacyTokenizer\n",
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {

--- a/tutorials/explainers/LIME/lime_text.ipynb
+++ b/tutorials/explainers/LIME/lime_text.ipynb
@@ -32,17 +32,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "\n",
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./data/movie_reviews_word_vectors.txt', './models/movie_review_model.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]\n",
+    "\n",
+    "    # download data used in this demo\n",
+    "    import os\n",
+    "    base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
+    "    paths_to_download = ['./data/movie_reviews_word_vectors.txt', './models/movie_review_model.onnx']\n",
+    "    for path in paths_to_download:\n",
+    "        !wget {base_url + path} -P {os.path.dirname(path)}\n",
+    "\n",
+    "    root_dir = Path(\".\").absolute()\n",
+    "else:\n",
+    "    # assume dianna is already installed, use data from the install folder\n",
+    "    import dianna\n",
+    "    root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
@@ -74,9 +82,7 @@
     "import spacy\n",
     "from torchtext.vocab import Vectors\n",
     "from scipy.special import expit as sigmoid\n",
-    "from pathlib import Path\n",
     "\n",
-    "import dianna\n",
     "from dianna import visualization\n",
     "from dianna import utils\n",
     "from dianna.utils.tokenizers import SpacyTokenizer"
@@ -93,8 +99,8 @@
    },
    "outputs": [],
    "source": [
-    "model_path = Path('..','..','..','dianna','models', 'movie_review_model.onnx')\n",
-    "word_vector_path = Path('..','..','..','dianna','data', 'movie_reviews_word_vectors.txt')\n",
+    "model_path = Path(root_dir, 'models', 'movie_review_model.onnx')\n",
+    "word_vector_path = Path(root_dir, 'data', 'movie_reviews_word_vectors.txt')\n",
     "labels = (\"negative\", \"positive\")"
    ]
   },
@@ -380,7 +386,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/LIME/lime_text.ipynb
+++ b/tutorials/explainers/LIME/lime_text.ipynb
@@ -69,6 +69,7 @@
     "from torchtext.vocab import Vectors\n",
     "from scipy.special import expit as sigmoid\n",
     "\n",
+    "import dianna\n",
     "from dianna import visualization\n",
     "from dianna import utils\n",
     "from dianna.utils.tokenizers import SpacyTokenizer\n",

--- a/tutorials/explainers/LIME/lime_text.ipynb
+++ b/tutorials/explainers/LIME/lime_text.ipynb
@@ -94,7 +94,7 @@
    "outputs": [],
    "source": [
     "model_path = Path('..','..','..','dianna','models', 'movie_review_model.onnx')\n",
-    "word_vector_path = Path('..','..','..','dianna','labels', 'movie_reviews_word_vectors.txt')\n",
+    "word_vector_path = Path('..','..','..','dianna','data', 'movie_reviews_word_vectors.txt')\n",
     "labels = (\"negative\", \"positive\")"
    ]
   },

--- a/tutorials/explainers/LIME/lime_timeseries_coffee.ipynb
+++ b/tutorials/explainers/LIME/lime_timeseries_coffee.ipynb
@@ -34,15 +34,8 @@
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./data/coffee_train.csv', './labels/coffee_test.csv', './models/coffee.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -68,7 +61,9 @@
     "import pandas as pd\n",
     "from sklearn.neighbors import KNeighborsClassifier as KNN\n",
     "from sklearn.metrics import accuracy_score as acc\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
@@ -91,12 +86,12 @@
    "outputs": [],
    "source": [
     "# Load coffee dataset\n",
-    "path_to_labels = \"../../../dianna/labels\"\n",
-    "coffee_train = pd.read_csv(Path(path_to_labels, \"coffee_train.csv\"),\n",
+    "path_to_labels = Path(root_dir, 'labels')\n",
+    "coffee_train = pd.read_csv(Path(path_to_labels, 'coffee_train.csv'),\n",
     "                            sep=',', header=None).astype(float)\n",
     "coffee_train_y = coffee_train.loc[:, 0]\n",
     "coffee_train_x = coffee_train.loc[:, 1:]\n",
-    "coffee_test = pd.read_csv(Path(path_to_labels, \"coffee_test.csv\"),\n",
+    "coffee_test = pd.read_csv(Path(path_to_labels, 'coffee_test.csv'),\n",
     "                           sep=',', header=None).astype(float)\n",
     "coffee_test_y = coffee_test.loc[:, 0]\n",
     "coffee_test_x = coffee_test.loc[:, 1:]"
@@ -310,7 +305,7 @@
    "source": [
     "from dianna.utils.onnx_runner import SimpleModelRunner\n",
     "\n",
-    "model_path = '../../../dianna//models/coffee.onnx'\n",
+    "model_path = Path(root_dir, 'models', 'coffee.onnx')\n",
     "loaded_model = SimpleModelRunner(model_path)\n",
     "predictions = loaded_model(data_instance.T.astype(np.float32))"
    ]
@@ -444,7 +439,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/LIME/lime_timeseries_weather.ipynb
+++ b/tutorials/explainers/LIME/lime_timeseries_weather.ipynb
@@ -29,15 +29,8 @@
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./models/season_prediction_model_temp_max_binary.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -54,6 +47,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "from pathlib import Path\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "from dianna import visualization\n",
@@ -63,7 +57,8 @@
     "import onnxruntime as ort\n",
     "import dianna\n",
     "\n",
-    "np.random.seed(0)"
+    "np.random.seed(0)\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
@@ -774,7 +769,7 @@
    "source": [
     "# onnx model available on surf drive\n",
     "# path to ONNX model\n",
-    "onnx_file = '../../../dianna/models/season_prediction_model_temp_max_binary.onnx'\n",
+    "onnx_file = Path(root_dir, 'models', 'season_prediction_model_temp_max_binary.onnx')\n",
     "\n",
     "# verify the ONNX model is valid\n",
     "onnx_model = onnx.load(onnx_file)\n",
@@ -920,7 +915,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -934,7 +929,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/RISE/rise_imagenet.ipynb
+++ b/tutorials/explainers/RISE/rise_imagenet.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "69dcce5d",
    "metadata": {},
    "source": [
     "<img width=\"150\" alt=\"Logo_ER10\" src=\"https://user-images.githubusercontent.com/3244249/151994514-b584b984-a148-4ade-80ee-0f88b0aefa45.png\">\n",
@@ -16,6 +17,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5f3d063c",
    "metadata": {},
    "source": [
     "#### Colab Setup"
@@ -24,24 +26,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "5e5da63d",
    "metadata": {},
    "outputs": [],
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./data/bee.jpg']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "a767530b",
    "metadata": {},
    "source": [
     "#### 0 -  Libraries"
@@ -50,6 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9d4cbba6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,11 +64,14 @@
     "from dianna import visualization\n",
     "# for plotting\n",
     "%matplotlib inline\n",
-    "from matplotlib import pyplot as plt"
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "52107bc8",
    "metadata": {},
    "source": [
     "#### 1 - Loading the model and the dataset\n",
@@ -79,6 +80,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1eee4d03",
    "metadata": {},
    "source": [
     "Initialize the pretrained model."
@@ -87,6 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "8f068783",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,6 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "2c4ec473",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,6 +115,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3b9415de",
    "metadata": {},
    "source": [
     "Load and preprocess image."
@@ -119,6 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "616469b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,6 +137,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c6214be9",
    "metadata": {},
    "source": [
     "Call the function to load an image of a single instance in the test data from the `img` folder."
@@ -139,6 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "3ce4c806",
    "metadata": {},
    "outputs": [
     {
@@ -163,12 +171,13 @@
     }
    ],
    "source": [
-    "img, x = load_img(Path('..','..','..','dianna','data', 'bee.jpg'))\n",
+    "img, x = load_img(Path(root_dir, 'data', 'bee.jpg'))\n",
     "plt.imshow(img)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "097419cd",
    "metadata": {},
    "source": [
     "#### 2 - Compute and visualize the relevance scores\n",
@@ -177,6 +186,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2c65e16c",
    "metadata": {},
    "source": [
     "RISE masks random portions of the input image and passes the masked image through the model — the masked portion that decreases accuracy the most is the most “important” portion.<br>\n",
@@ -186,6 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "71fb94af",
    "metadata": {},
    "outputs": [
     {
@@ -349,6 +360,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d248a326",
    "metadata": {},
    "source": [
     "Make predictions and select the top prediction.\n"
@@ -357,6 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "b085ac4c",
    "metadata": {},
    "outputs": [
     {
@@ -387,6 +400,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "98fee6fc",
    "metadata": {},
    "source": [
     "Visualize the relevance scores for the predicted class on top of the input image."
@@ -395,6 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "3e4d358c",
    "metadata": {},
    "outputs": [
     {
@@ -424,6 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "d6da1c73",
    "metadata": {
     "tags": []
    },
@@ -523,6 +539,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d3ab048b",
    "metadata": {},
    "source": [
     "#### 3 - Conclusions\n",
@@ -534,7 +551,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -548,7 +565,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/RISE/rise_mnist.ipynb
+++ b/tutorials/explainers/RISE/rise_mnist.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "dd073a9d",
    "metadata": {},
    "source": [
     "<img width=\"150\" alt=\"Logo_ER10\" src=\"https://user-images.githubusercontent.com/3244249/151994514-b584b984-a148-4ade-80ee-0f88b0aefa45.png\">\n",
@@ -15,6 +16,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "731728b1",
    "metadata": {},
    "source": [
     "### Colab Setup"
@@ -23,24 +25,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "b04da052",
    "metadata": {},
    "outputs": [],
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./data/binary-mnist.npz', './models/mnist_model.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "d7516aee",
    "metadata": {},
    "source": [
     "### Libraries"
@@ -49,9 +46,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "0975a61d",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "import warnings\n",
     "warnings.filterwarnings('ignore') # disable warnings relateds to versions of tf\n",
     "import dianna\n",
@@ -61,11 +60,14 @@
     "%matplotlib inline\n",
     "from matplotlib import pyplot as plt\n",
     "from scipy.special import softmax\n",
-    "from dianna import visualization"
+    "from dianna import visualization\n",
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "43d79a04",
    "metadata": {},
    "source": [
     "#### 1 - Loading the model and the dataset\n",
@@ -74,6 +76,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4a05f279",
    "metadata": {},
    "source": [
     "Load saved binary MNIST data."
@@ -82,11 +85,12 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "767a183f",
    "metadata": {},
    "outputs": [],
    "source": [
     "# load dataset\n",
-    "data = np.load(Path('..','..','..','dianna','data', 'binary-mnist.npz'))\n",
+    "data = np.load(Path(root_dir, 'data', 'binary-mnist.npz'))\n",
     "# load testing data and the related labels\n",
     "X_test = data['X_test'].astype(np.float32).reshape([-1, 1, 28, 28])\n",
     "y_test = data['y_test']"
@@ -94,6 +98,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b3d3f6e7",
    "metadata": {},
    "source": [
     "Load the pretrained binary MNIST model and define a model runner."
@@ -102,11 +107,12 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "40de1f6e",
    "metadata": {},
    "outputs": [],
    "source": [
     "def run_model(data):\n",
-    "    fname = str(Path('..','..','..','dianna','models', 'mnist_model.onnx'))\n",
+    "    fname = str(Path(root_dir, 'models', 'mnist_model.onnx'))\n",
     "    # get ONNX predictions\n",
     "    sess = onnxruntime.InferenceSession(fname)\n",
     "    input_name = sess.get_inputs()[0].name\n",
@@ -122,6 +128,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "802b6fd3",
    "metadata": {},
    "source": [
     "Print class and image of a single instance in the test data for preview."
@@ -130,6 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "de15bd4d",
    "metadata": {},
    "outputs": [
     {
@@ -173,6 +181,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "222af804",
    "metadata": {},
    "source": [
     "#### 2 - Compute and visualize the relevance attributions\n",
@@ -181,6 +190,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7224bb0d",
    "metadata": {},
    "source": [
     "RISE masks random portions of the input image and passes the masked image through the model — the portion that decreases the accuracy the most is the most “important” portion.<br>\n",
@@ -190,6 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "87212eac",
    "metadata": {},
    "outputs": [
     {
@@ -209,6 +220,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "88278094",
    "metadata": {},
    "source": [
     "Visualize the relevance scores for the predicted class on top of the image."
@@ -217,6 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "49ce231f",
    "metadata": {},
    "outputs": [
     {
@@ -244,6 +257,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1004be3",
    "metadata": {},
    "source": [
     "#### 3 - Conclusions\n",
@@ -255,7 +269,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -269,7 +283,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/RISE/rise_text.ipynb
+++ b/tutorials/explainers/RISE/rise_text.ipynb
@@ -35,20 +35,7 @@
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
     "    # install dianna\n",
-    "    !python3 -m pip install dianna[notebooks]\n",
-    "\n",
-    "    # download data used in this demo\n",
-    "    import os\n",
-    "    base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "    paths_to_download = ['./data/movie_reviews_word_vectors.txt', './models/movie_review_model.onnx']\n",
-    "    for path in paths_to_download:\n",
-    "        !wget {base_url + path} -P {os.path.dirname(path)}\n",
-    "\n",
-    "    root_dir = Path(\".\").absolute()\n",
-    "else:\n",
-    "    # assume dianna is already installed, use data from the install folder\n",
-    "    import dianna\n",
-    "    root_dir = Path(dianna.__file__).parent"
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -76,7 +63,9 @@
     "import dianna\n",
     "from dianna import visualization\n",
     "from dianna import utils\n",
-    "from dianna.utils.tokenizers import SpacyTokenizer"
+    "from dianna.utils.tokenizers import SpacyTokenizer\n",
+    "\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {

--- a/tutorials/explainers/RISE/rise_text.ipynb
+++ b/tutorials/explainers/RISE/rise_text.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "8179c57c",
    "metadata": {},
    "source": [
     "<img width=\"150\" alt=\"Logo_ER10\" src=\"https://user-images.githubusercontent.com/3244249/151994514-b584b984-a148-4ade-80ee-0f88b0aefa45.png\">\n",
@@ -16,6 +17,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "242b796c",
    "metadata": {},
    "source": [
     "#### Colab Setup"
@@ -24,24 +26,34 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "897b2477",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "\n",
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./data/movie_reviews_word_vectors.txt', './models/movie_review_model.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]\n",
+    "\n",
+    "    # download data used in this demo\n",
+    "    import os\n",
+    "    base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
+    "    paths_to_download = ['./data/movie_reviews_word_vectors.txt', './models/movie_review_model.onnx']\n",
+    "    for path in paths_to_download:\n",
+    "        !wget {base_url + path} -P {os.path.dirname(path)}\n",
+    "\n",
+    "    root_dir = Path(\".\").absolute()\n",
+    "else:\n",
+    "    # assume dianna is already installed, use data from the install folder\n",
+    "    import dianna\n",
+    "    root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "50fd3dee",
    "metadata": {},
    "source": [
     "#### 0 -  Imports and paths"
@@ -50,13 +62,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "f705ebfe",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from pathlib import Path\n",
     "import spacy\n",
     "from torchtext.vocab import Vectors\n",
     "from scipy.special import expit as sigmoid\n",
@@ -70,16 +82,18 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "79b95d61",
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_path = Path('..','..','..','dianna','models', 'movie_review_model.onnx')\n",
-    "word_vector_path = Path('..','..','..','dianna','data', 'movie_reviews_word_vectors.txt')\n",
+    "model_path = Path(root_dir, 'models', 'movie_review_model.onnx')\n",
+    "word_vector_path = Path(root_dir, 'data', 'movie_reviews_word_vectors.txt')\n",
     "labels = (\"negative\", \"positive\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "f42c4b53",
    "metadata": {},
    "source": [
     "#### 1 - Loading the model\n",
@@ -91,6 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "712db400",
    "metadata": {
     "tags": []
    },
@@ -145,6 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "d558af74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,6 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "48c268ba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,6 +212,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1d182278",
    "metadata": {},
    "source": [
     "#### 2 - Applying RISE with DIANNA\n",
@@ -210,6 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "2d21c06e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,6 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "d65cf3e6",
    "metadata": {},
    "outputs": [
     {
@@ -279,6 +299,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "858293ed",
    "metadata": {},
    "source": [
     "#### 3 - Visualization\n",
@@ -289,6 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "ef1f6353",
    "metadata": {},
    "outputs": [
     {
@@ -308,6 +330,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "08b7e149",
    "metadata": {},
    "source": [
     "The visualization is not very clear, as all words seem relevant for the review's outcome. From the numerical values above, we see that indeed all words contribute positively according to RISE, with \"intriguing\" as the most important word with a score of 0.94."
@@ -316,7 +339,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -330,7 +353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tutorials/explainers/RISE/rise_text.ipynb
+++ b/tutorials/explainers/RISE/rise_text.ipynb
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "model_path = Path('..','..','..','dianna','models', 'movie_review_model.onnx')\n",
-    "word_vector_path = Path('..','..','..','dianna','labels', 'movie_reviews_word_vectors.txt')\n",
+    "word_vector_path = Path('..','..','..','dianna','data', 'movie_reviews_word_vectors.txt')\n",
     "labels = (\"negative\", \"positive\")"
    ]
   },

--- a/tutorials/explainers/RISE/rise_timeseries_frb.ipynb
+++ b/tutorials/explainers/RISE/rise_timeseries_frb.ipynb
@@ -37,14 +37,7 @@
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
     "    # install dianna\n",
-    "    !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "    # download data used in this demo\n",
-    "    import os \n",
-    "    base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "    paths_to_download = ['labels/arts_frb_classes.txt', 'data/FRB211024.npy']\n",
-    "    for path in paths_to_download:\n",
-    "        !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -80,6 +73,7 @@
      "end_time": "2023-05-30T16:49:27.399443Z",
      "start_time": "2023-05-30T16:49:17.537497Z"
     },
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -89,13 +83,15 @@
    },
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "import numpy as np\n",
     "from dianna import visualization\n",
     "from matplotlib import pyplot as plt\n",
     "import dianna\n",
     "from dianna.utils import SimpleModelRunner\n",
     "\n",
-    "np.random.seed(0)"
+    "np.random.seed(0)\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
@@ -104,8 +100,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "classes_path = '../../../dianna/labels/apertif_frb_classes.txt'\n",
-    "data_path = '../../../dianna/data/FRB211024.npy'"
+    "classes_path = Path(root_dir, 'labels', 'apertif_frb_classes.txt')\n",
+    "data_path = Path(root_dir, 'data', 'FRB211024.npy')"
    ]
   },
   {
@@ -598,7 +594,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -612,7 +608,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   },
   "vscode": {
    "interpreter": {

--- a/tutorials/explainers/RISE/rise_timeseries_weather.ipynb
+++ b/tutorials/explainers/RISE/rise_timeseries_weather.ipynb
@@ -40,15 +40,8 @@
    "source": [
     "running_in_colab = 'google.colab' in str(get_ipython())\n",
     "if running_in_colab:\n",
-    "  # install dianna\n",
-    "  !python3 -m pip install dianna[notebooks]\n",
-    "  \n",
-    "  # download data used in this demo\n",
-    "  import os \n",
-    "  base_url = 'https://raw.githubusercontent.com/dianna-ai/dianna/main/dianna/'\n",
-    "  paths_to_download = ['./models/season_prediction_model_temp_max_binary.onnx']\n",
-    "  for path in paths_to_download:\n",
-    "      !wget {base_url + path} -P {os.path.dirname(path)}"
+    "    # install dianna\n",
+    "    !python3 -m pip install dianna[notebooks]"
    ]
   },
   {
@@ -82,7 +75,8 @@
     "import onnxruntime as ort\n",
     "import dianna\n",
     "\n",
-    "np.random.seed(0)"
+    "np.random.seed(0)\n",
+    "root_dir = Path(dianna.__file__).parent"
    ]
   },
   {
@@ -931,7 +925,7 @@
    "source": [
     "# onnx model available on surf drive\n",
     "# path to ONNX model\n",
-    "onnx_file = '../../../dianna/models/season_prediction_model_temp_max_binary.onnx'\n",
+    "onnx_file = Path(root_dir, 'models', 'season_prediction_model_temp_max_binary.onnx')\n",
     "\n",
     "# verify the ONNX model is valid\n",
     "onnx_model = onnx.load(onnx_file)\n",
@@ -1098,7 +1092,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1112,7 +1106,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   },
   "vscode": {
    "interpreter": {

--- a/tutorials/explainers/RISE/rise_timeseries_weather.ipynb
+++ b/tutorials/explainers/RISE/rise_timeseries_weather.ipynb
@@ -65,6 +65,7 @@
    },
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "import os\n",
     "import pandas as pd\n",
     "import numpy as np\n",


### PR DESCRIPTION
Use files from dianna installation folder in all tutorials.
    
This simplifies the colab setup as we no longer need to download data
files.

The relative paths throughout the tutorials were replaced by paths
starting from the dianna install dir, which should work on all
platforms.

The indentation in the colab setup was also fixed, this was 2 spaces
instead of 4 in many places.

Fixes #750 