### PR TITLE
738 text lime in dashboard returns an error

### DIFF
--- a/dianna/dashboard/_models_image.py
+++ b/dianna/dashboard/_models_image.py
@@ -1,6 +1,5 @@
 import tempfile
 import streamlit as st
-from _model_utils import fill_segmentation
 from _model_utils import preprocess_function
 from onnx_tf.backend import prepare
 from dianna import explain_image

--- a/dianna/dashboard/_models_image.py
+++ b/dianna/dashboard/_models_image.py
@@ -42,12 +42,12 @@ def _run_kernelshap_image(model, image, i, **kwargs):
     with tempfile.NamedTemporaryFile() as f:
         f.write(model)
         f.flush()
-        shap_values, segments_slic = explain_image(f.name,
-                                                   image,
-                                                   method='KernelSHAP',
-                                                   **kwargs)
-
-    return fill_segmentation(shap_values[i][0], segments_slic)
+        relevances = explain_image(f.name,
+                image,
+                method='KernelSHAP',
+                **kwargs)
+    #return fill_segmentation(relevances[i][0], segments_slic)
+    return relevances[0]
 
 
 explain_image_dispatcher = {

--- a/dianna/dashboard/_models_image.py
+++ b/dianna/dashboard/_models_image.py
@@ -45,7 +45,6 @@ def _run_kernelshap_image(model, image, i, **kwargs):
                 image,
                 method='KernelSHAP',
                 **kwargs)
-    #return fill_segmentation(relevances[i][0], segments_slic)
     return relevances[0]
 
 

--- a/dianna/dashboard/_shared.py
+++ b/dianna/dashboard/_shared.py
@@ -90,7 +90,7 @@ def _get_params(method: str):
 
     elif method == 'LIME':
         return {
-            'rand_state': st.number_input('Random state', value=2),
+            'random_state': st.number_input('Random state', value=2),
         }
 
     else:

--- a/dianna/dashboard/_shared.py
+++ b/dianna/dashboard/_shared.py
@@ -88,11 +88,6 @@ def _get_params(method: str):
             'sigma': st.number_input('σ', value=0),
         }
 
-    elif method == 'LIME':
-        return {
-            'rand_state': st.number_input('Random state', value=2),
-        }
-
     else:
         raise ValueError(f'No such method: {method}')
 

--- a/dianna/dashboard/_shared.py
+++ b/dianna/dashboard/_shared.py
@@ -88,6 +88,11 @@ def _get_params(method: str):
             'sigma': st.number_input('σ', value=0),
         }
 
+    elif method == 'LIME':
+        return {
+            'rand_state': st.number_input('Random state', value=2),
+        }
+
     else:
         raise ValueError(f'No such method: {method}')
 

--- a/dianna/methods/lime_timeseries.py
+++ b/dianna/methods/lime_timeseries.py
@@ -33,6 +33,7 @@ class LIMETimeseries:
             feature_selection (str): Feature selection method to be used by explainer.
             preprocess_function (callable, optional): Function to preprocess the time series data before passing it
                                                       to the explainer. Defaults to None.
+            random_state (int or np.RandomState, optional): seed or random state. Unused variable for current ts method
         """
 
         def kernel(d):

--- a/dianna/methods/lime_timeseries.py
+++ b/dianna/methods/lime_timeseries.py
@@ -23,6 +23,7 @@ class LIMETimeseries:
         verbose=False,
         preprocess_function=None,
         feature_selection='auto',
+        random_state = None
     ):
         """Initializes Lime explainer for timeseries.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,7 @@ dashboard =
     spacy
     streamlit
     torchtext
+    watchdog
 notebooks =
     keras
     nbmake

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,6 @@ dashboard =
     spacy
     streamlit
     torchtext
-    watchdog
 notebooks =
     keras
     nbmake

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -109,11 +109,11 @@ def test_text_page(page: Page):
 
     for selector in (
             page.get_by_role('heading', name='RISE').get_by_text('RISE'),
-            page.get_by_role('heading', name='LIME').get_by_text('LIME'),            
+            page.get_by_role('heading', name='LIME').get_by_text('LIME'),
             # Images for positive (RISE/LIME)
             page.get_by_role('heading',
                              name='positive').get_by_text('positive'),
-            page.get_by_role('img', name='0').first,            
+            page.get_by_role('img', name='0').first,
             page.get_by_role('img', name='0').nth(1),
 
             # Images for negative (RISE/LIME)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -103,19 +103,24 @@ def test_text_page(page: Page):
     expect(page.get_by_text('Select a method to continue')).to_be_visible()
 
     page.locator('label').filter(has_text='RISE').locator('span').click()
+    page.locator('label').filter(has_text='LIME').locator('span').click()
 
     page.get_by_text('Running...').wait_for(state='detached', timeout=45_000)
 
     for selector in (
             page.get_by_role('heading', name='RISE').get_by_text('RISE'),
-            # first image
+            page.get_by_role('heading', name='LIME').get_by_text('LIME'),            
+            # Images for positive (RISE/LIME)
             page.get_by_role('heading',
                              name='positive').get_by_text('positive'),
-            page.get_by_role('img', name='0').first,
-            # second image
+            page.get_by_role('img', name='0').first,            
+            page.get_by_role('img', name='0').nth(1),
+
+            # Images for negative (RISE/LIME)
             page.get_by_role('heading',
                              name='negative').get_by_text('negative'),
-            page.get_by_role('img', name='0').nth(1),
+            page.get_by_role('img', name='0').nth(2),
+            page.get_by_role('img', name='0').nth(3),
     ):
         print(selector)
         expect(selector).to_be_visible()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -144,17 +144,25 @@ def test_image_page(page: Page):
     expect(page.get_by_text('Select a method to continue')).to_be_visible()
 
     page.locator('label').filter(has_text='RISE').locator('span').click()
+    page.locator('label').filter(has_text='KernelSHAP').locator('span').click()
+    page.locator('label').filter(has_text='LIME').locator('span').click()
 
     page.get_by_text('Running...').wait_for(state='detached', timeout=45_000)
 
     for selector in (
             page.get_by_role('heading', name='RISE').get_by_text('RISE'),
+            page.get_by_role('heading', name='KernelSHAP').get_by_text('KernelSHAP'),
+            page.get_by_role('heading', name='LIME').get_by_text('LIME'),
             # first image
             page.get_by_role('heading', name='0').get_by_text('0'),
             page.get_by_role('img', name='0').first,
+            page.get_by_role('img', name='0').nth(1),
+            page.get_by_role('img', name='0').nth(2),
             # second image
             page.get_by_role('heading', name='1').get_by_text('1'),
-            page.get_by_role('img', name='0').nth(1),
+            page.get_by_role('img', name='0').nth(3),
+            page.get_by_role('img', name='0').nth(4),
+            page.get_by_role('img', name='0').nth(5),
     ):
         expect(selector).to_be_visible(timeout=45_000)
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -105,7 +105,7 @@ def test_text_page(page: Page):
     page.locator('label').filter(has_text='RISE').locator('span').click()
     page.locator('label').filter(has_text='LIME').locator('span').click()
 
-    page.get_by_text('Running...').wait_for(state='detached', timeout=45_000)
+    page.get_by_text('Running...').wait_for(state='detached', timeout=60_000)
 
     for selector in (
             page.get_by_role('heading', name='RISE').get_by_text('RISE'),
@@ -136,7 +136,7 @@ def test_image_page(page: Page):
 
     expect(
         page.get_by_text('Add your input data in the left panel to continue')
-    ).to_be_visible(timeout=30_000)
+    ).to_be_visible(timeout=45_000)
 
     page.locator('label').filter(
         has_text='Load example data').locator('span').click()
@@ -164,7 +164,7 @@ def test_image_page(page: Page):
             page.get_by_role('img', name='0').nth(4),
             page.get_by_role('img', name='0').nth(5),
     ):
-        expect(selector).to_be_visible(timeout=45_000)
+        expect(selector).to_be_visible(timeout=60_000)
 
 
 def test_timeseries_page(page: Page):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -184,17 +184,21 @@ def test_timeseries_page(page: Page):
 
     expect(page.get_by_text('Select a method to continue')).to_be_visible()
 
+    page.locator('label').filter(has_text='LIME').locator('span').click()
     page.locator('label').filter(has_text='RISE').locator('span').click()
 
-    page.get_by_text('Running...').wait_for(state='detached', timeout=45_000)
+    page.get_by_text('Running...').wait_for(state='detached', timeout=60_000)
 
     for selector in (
+            page.get_by_role('heading', name='LIME').get_by_text('LIME'),
             page.get_by_role('heading', name='RISE').get_by_text('RISE'),
             # first image
             page.get_by_role('heading', name='winter').get_by_text('winter'),
             page.get_by_role('img', name='0').first,
+            page.get_by_role('img', name='0').nth(1),
             # second image
             page.get_by_role('heading', name='summer').get_by_text('summer'),
-            page.get_by_role('img', name='0').nth(1),
+            page.get_by_role('img', name='0').nth(2),
+            page.get_by_role('img', name='0').nth(3),
     ):
         expect(selector).to_be_visible()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -105,7 +105,7 @@ def test_text_page(page: Page):
     page.locator('label').filter(has_text='RISE').locator('span').click()
     page.locator('label').filter(has_text='LIME').locator('span').click()
 
-    page.get_by_text('Running...').wait_for(state='detached', timeout=60_000)
+    page.get_by_text('Running...').wait_for(state='detached', timeout=100_000)
 
     for selector in (
             page.get_by_role('heading', name='RISE').get_by_text('RISE'),
@@ -136,7 +136,7 @@ def test_image_page(page: Page):
 
     expect(
         page.get_by_text('Add your input data in the left panel to continue')
-    ).to_be_visible(timeout=45_000)
+    ).to_be_visible(timeout=100_000)
 
     page.locator('label').filter(
         has_text='Load example data').locator('span').click()
@@ -164,7 +164,7 @@ def test_image_page(page: Page):
             page.get_by_role('img', name='0').nth(4),
             page.get_by_role('img', name='0').nth(5),
     ):
-        expect(selector).to_be_visible(timeout=60_000)
+        expect(selector).to_be_visible(timeout=100_000)
 
 
 def test_timeseries_page(page: Page):
@@ -187,7 +187,7 @@ def test_timeseries_page(page: Page):
     page.locator('label').filter(has_text='LIME').locator('span').click()
     page.locator('label').filter(has_text='RISE').locator('span').click()
 
-    page.get_by_text('Running...').wait_for(state='detached', timeout=60_000)
+    page.get_by_text('Running...').wait_for(state='detached', timeout=100_000)
 
     for selector in (
             page.get_by_role('heading', name='LIME').get_by_text('LIME'),


### PR DESCRIPTION
This PR fixes #738 

Lime runs into an error because of a typo in the variable name -> rand_state instead of random_state.
Additionally lime timeseries does not have this variable, which also returns an error, since the random_state variable is used in all LIME methods. Although random_state is not used in lime timeseries, adding the variable to the class fixes the issue.

Edit:
Added tests for dashboard text, image, and timeseries for LIME and KernelSHAP to complete the dashboard tests. It turned out that the dashboard was actually not working for images with KernelSHAP. I made changes in dashboard/_models_image.py to do this, but I am not sure of the changes are 100% correct. Can someone please check @cwmeijer @loostrum maybe?