### PR TITLE
Fix notebook tests

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -17,17 +17,19 @@ on:
 jobs:
 
   notebooks:
-    name: Run notebooks on (3.10, ${{ matrix.os }})
+    name: Run notebooks on (${{ matrix.python-version }}, ${{ matrix.os }})
     if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-python-and-package
         with:
+          python-version: ${{ matrix.python-version }}
           extras-require: dev,notebooks
       - name: Run tutorial notebooks
         run: pytest --nbmake tutorials

--- a/dianna/utils/onnx_runner.py
+++ b/dianna/utils/onnx_runner.py
@@ -3,6 +3,7 @@ import onnxruntime as ort
 
 class SimpleModelRunner:
     """Runs an onnx model with a set of inputs and outputs."""
+
     def __init__(self, filename, preprocess_function=None):
         """Generates function to run ONNX model with one set of inputs and outputs.
 
@@ -22,7 +23,9 @@ class SimpleModelRunner:
 
     def __call__(self, input_data):
         """Get ONNX predictions."""
-        sess = ort.InferenceSession(self.filename)
+        sess_options = ort.SessionOptions()
+        sess_options.enable_cpu_mem_arena = False  # disables pre-allocation of memory
+        sess = ort.InferenceSession(self.filename, sess_options=sess_options)
         input_name = sess.get_inputs()[0].name
         output_name = sess.get_outputs()[0].name
 


### PR DESCRIPTION
As a first change I made the Python version used to run the tutorial notebooks more robust in the CI file. This is not that important, but was mainly so I could open a PR and trigger the CI to run on the notebooks.

The failing tests seem to be due to the Github runner being out of memory. I noticed locally that the lime_images tutorial uses all my available RAM. The test does pass locally, but perhaps this is the issue. There is an option to disable some pre-allocation of memory by ONNX, see [here](https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.enable_cpu_mem_arena).
I've added that option to our `SimpleModelRunner`. This drastically reduces the memory usage.

Tests now pass on CI as well.