### PR TITLE
add support for python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: ./.github/actions/install-python-and-package
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Run unit tests
         run: pytest -v
@@ -40,10 +40,10 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.9', '3.11']
+        python-version: ['3.9', '3.12']
         exclude:
           # already tested in build_single job
-          - python-version: 3.11
+          - python-version: 3.12
             os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-python-and-package
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           extras-require: dev
       - name: Run downloader test
         run: python -m pytest -v --downloader -k downloader
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-python-and-package
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           extras-require: dev,dashboard
 
       - name: Ensure browser is installed

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 description = Deep Insight And Neural Network Analysis
 keywords =
     XAI
@@ -30,7 +31,7 @@ version = 1.7.0
 license = Apache License 2.0
 
 [options]
-python_requires = >=3.8,<3.12
+python_requires = >=3.8,<3.13
 zip_safe = False
 include_package_data = True
 packages = find_namespace:

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     pandas
     torch <=2.3.1  # this is temporary, see #829
     # tf and tfprob are required but not declared by onnx_tf
-    tensorflow >= 2.12,<2.16
+    tensorflow >= 2.12
     tensorflow_probability <0.24
     # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
     importlib_resources;python_version<'3.10'

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     lime
     matplotlib
     numpy>=1.20
-    onnx==1.14.1
     onnx_tf
     onnxruntime
     pooch


### PR DESCRIPTION
This PR should fix #873.

My progress so far:
- To support 3.12, we had to drop the restriction of TF as only newer versions support 3.12.
- To support newer versions of TF we had to drop our restrictions for onnx.
 
Current status however: 3 build tests fail.

My approach for both dependency conflicts was to remove the problematic restrictions completely. Maybe we should instead only loosen the restrictions to make the tests pass again. I haven't looked into that yet. For now, I'll leave this PR here for anyone who feels like diving into this.