### PR TITLE
fix release action

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.0
+current_version = 1.8.0
 
 [comment]
 comment = The contents of this file cannot be merged with that of setup.cfg until https://github.com/c4urself/bump2version/issues/185 is resolved

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,8 @@ jobs:
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 
@@ -45,7 +44,6 @@ jobs:
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ jobs:
   upload_test_pypi:
     needs: [build]
     runs-on: ubuntu-latest
+    environment: testpypi_release
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
     if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/download-artifact@v8
@@ -32,12 +36,15 @@ jobs:
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
 
   upload_pypi:
     needs: [build]
     runs-on: ubuntu-latest
+    environment: pypi_release
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v8
@@ -45,5 +52,3 @@ jobs:
           name: artifact
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -53,7 +53,7 @@ authors:
     name-particle: "van der"
 
 doi: 10.5281/zenodo.5801485
-version: "1.7.0"
+version: "1.8.0"
 repository-code: "https://github.com/dianna-ai/dianna"
 keywords:
   - XAI

--- a/dianna/__init__.py
+++ b/dianna/__init__.py
@@ -32,7 +32,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __author__ = 'DIANNA Team'
 __email__ = 'dianna-ai@esciencecenter.nl'
-__version__ = '1.7.0'
+__version__ = '1.8.0'
 
 
 def explain_timeseries(model_or_function: Union[Callable, str],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u'DIANNA Team'
 # built documents.
 #
 # The short X.Y version.
-version = '1.7.0'
+version = '1.8.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ name = dianna
 project_urls =
     Bug Tracker = https://github.com/dianna-ai/dianna/issues
 url = https://github.com/dianna-ai/dianna
-version = 1.7.0
+version = 1.8.0
 license = Apache License 2.0
 
 [options]


### PR DESCRIPTION
Updated the pypa/gh-action-pypi-publish action to use the release version ("v1" no longer exists).

Also removes the explicit __token__ user, because it is the default, no need to specify anymore.

Note: this PR does not activate trusted publishing, which is the recommended mode nowadays (https://github.com/marketplace/actions/pypi-publish), but I don't have access to set it up on PyPI.