### PR TITLE
Fix click CI failure

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ install_requires =
 [options.extras_require]
 dev =
     bump2version
+    click # workaround for https://github.com/explosion/spaCy/issues/13971, should be removed when fixed in spacy
     pre-commit
     scipy
     spacy

--- a/tests/methods/test_maskers.py
+++ b/tests/methods/test_maskers.py
@@ -110,7 +110,7 @@ def _get_univariate_time_series(num_steps=10) -> np.array:
 
 def _get_multivariate_time_series(number_of_channels: int = 6) -> np.array:
     """Get some multivariate test data."""
-    return np.row_stack([
+    return np.vstack([
         np.zeros((10, number_of_channels)),
         np.ones((10, number_of_channels))
     ])


### PR DESCRIPTION
Fixes #893. Also replace deprecated Numpy `row_stack` with `vstack` (which is simply an alias, so no change in behaviour).